### PR TITLE
Add MQTT autodiscovery preferences page

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA – Autodiscovery</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #151924;
+      --panel-2: #1b2131;
+      --accent: #31c4ff;
+      --text: #e7ecf4;
+      --muted: #9aa7bd;
+      --border: rgba(255,255,255,0.08);
+      --shadow: 0 10px 30px rgba(0,0,0,0.45);
+    }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+    a { color: inherit; text-decoration: none; }
+    header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
+    .brand-line { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
+    .brand-line h1 { margin:0; font-size:1.1rem; letter-spacing:0.1em; text-transform:uppercase; }
+    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
+    nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
+    .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
+    .tab:hover { color: var(--text); border-color: var(--border); }
+    .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
+    .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
+    .meta { color: var(--muted); font-size:0.9rem; }
+    .title { margin:0 0 6px 0; font-size:1rem; }
+    .stack { background: var(--panel); border:1px solid var(--border); border-radius:14px; box-shadow: var(--shadow); }
+    .stack-header { display:flex; align-items:center; justify-content:space-between; padding:12px 14px; border-bottom:1px solid var(--border); gap:10px; flex-wrap:wrap; }
+    .stack-title { font-weight:800; }
+    .stack-chip { padding:4px 10px; border-radius:999px; background: rgba(255,255,255,0.05); color: var(--muted); font-size:0.8rem; }
+    table { width:100%; border-collapse: collapse; }
+    th, td { padding:10px 12px; border-bottom:1px solid var(--border); font-size:0.85rem; text-align:left; }
+    th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing:0.04em; font-size:0.78rem; }
+    tr:last-child td { border-bottom:none; }
+    tr:nth-child(even) td { background: rgba(255,255,255,0.01); }
+    .checkbox { display:flex; justify-content:center; align-items:center; }
+    .checkbox input { width:18px; height:18px; accent-color: var(--accent); }
+    .name { font-weight:700; }
+    .muted { color: var(--muted); font-size:0.85rem; }
+    .actions-bar { display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+    .btn-primary { background: linear-gradient(135deg, #1b87f1, #31c4ff); border:none; color:#0b111c; border-radius:12px; padding:10px 16px; font-weight:800; cursor:pointer; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .note { background: rgba(49,196,255,0.08); border:1px solid rgba(49,196,255,0.25); padding:10px 12px; border-radius:12px; font-size:0.9rem; }
+    @media(max-width: 960px) {
+      table, thead, tbody, th, td, tr { display:block; }
+      thead { display:none; }
+      tr { margin-bottom:10px; border:1px solid var(--border); border-radius:10px; overflow:hidden; }
+      td { display:flex; justify-content: space-between; align-items:center; padding:10px; }
+      td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
+      .checkbox { justify-content:flex-end; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="brand-line">
+      <h1>D2HA <span class="brand-pill">Autodiscovery</span></h1>
+    </div>
+    <nav>
+      <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+      <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
+      <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
+      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="card">
+      <div class="actions-bar">
+        <div>
+          <h3 class="title">Entità MQTT esposte</h3>
+          <div class="meta">{{ summary.running }} container attivi · {{ summary.total_containers }} totali · {{ summary.images }} immagini installate</div>
+        </div>
+        <button type="submit" form="autodiscovery-form" class="btn-primary">Salva preferenze</button>
+      </div>
+      <div class="note">Seleziona quali entità Home Assistant devono essere create per ogni container. Le modifiche aggiornano automaticamente l'autodiscovery e lo stato corrente.</div>
+    </section>
+
+    <form id="autodiscovery-form" method="POST">
+      {% for stack, containers in stack_map.items() %}
+        <section class="stack">
+          <div class="stack-header">
+            <div class="stack-title">{{ 'Senza stack' if stack == '_no_stack' else stack }}</div>
+            <div class="stack-chip">{{ containers|length }} container</div>
+          </div>
+          <div style="overflow-x:auto;">
+            <table>
+              <thead>
+                <tr>
+                  <th>Container</th>
+                  <th>Immagine</th>
+                  <th>Stato</th>
+                  <th>Autodiscovery stato</th>
+                  {% for action in actions %}
+                    <th>{{ action.replace('_', ' ')|title }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for c in containers %}
+                  {% set pref = preferences.get(c.stable_id, {'state': True, 'actions': {}}) %}
+                  <tr>
+                    <td data-label="Container">
+                      <div class="name">{{ c.name }}</div>
+                      <div class="muted">{{ c.short_id }}</div>
+                    </td>
+                    <td data-label="Immagine">{{ c.image }}</td>
+                    <td data-label="Stato">{{ c.status }}</td>
+                    <td data-label="Autodiscovery stato" class="checkbox">
+                      <input type="checkbox" name="{{ c.stable_id }}_state" {% if pref.state %}checked{% endif %} />
+                    </td>
+                    {% for action in actions %}
+                      <td data-label="{{ action.replace('_', ' ')|title }}" class="checkbox">
+                        <input type="checkbox" name="{{ c.stable_id }}_{{ action }}" {% if pref.actions.get(action, True) %}checked{% endif %} />
+                      </td>
+                    {% endfor %}
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      {% endfor %}
+    </form>
+  </main>
+</body>
+</html>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -113,6 +113,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>
 

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -295,6 +295,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>
 

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -60,6 +60,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>
 

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -71,6 +71,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- add persisted autodiscovery preferences and stable IDs for MQTT exposure
- provide UI page with per-container checkboxes to control discovery of state and actions
- respect preferences when publishing MQTT autodiscovery and navigation links

## Testing
- python -m compileall d2ha

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fe5f4d40c8331a69b049e57114e88)