### PR TITLE
Exclude self container from autodiscovery UI

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -178,6 +178,9 @@ def updates():
 @app.route("/autodiscovery", methods=["GET", "POST"])
 def autodiscovery_view():
     containers_info = docker_service.collect_containers_info_for_updates()
+    containers_info = [
+        c for c in containers_info if not mqtt_manager.is_self_container(c)
+    ]
     stable_ids = [c.get("stable_id", "") for c in containers_info]
 
     if request.method == "POST":

--- a/d2ha/docker_service.py
+++ b/d2ha/docker_service.py
@@ -1012,6 +1012,16 @@ class MqttManager:
 
         return name in known_identifiers
 
+    def is_self_container(self, container_info: Dict[str, Any]) -> bool:
+        """Public wrapper around :meth:`_is_self_container`.
+
+        Exposing this check allows the web UI to hide the D2HA container from
+        manual autodiscovery configuration while keeping the MQTT filtering
+        logic centralized.
+        """
+
+        return self._is_self_container(container_info)
+
     def _on_connect(self, client, userdata, flags, rc, properties=None):
         topic = f"{self.base_topic}/+/set/+"
         self.logger.info("MQTT connected with result code %s, subscribing to %s", rc, topic)

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -47,12 +47,8 @@
     .btn-primary { background: linear-gradient(135deg, #1b87f1, #31c4ff); border:none; color:#0b111c; border-radius:12px; padding:10px 16px; font-weight:800; cursor:pointer; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
     .note { background: rgba(49,196,255,0.08); border:1px solid rgba(49,196,255,0.25); padding:10px 12px; border-radius:12px; font-size:0.9rem; }
     @media(max-width: 960px) {
-      table, thead, tbody, th, td, tr { display:block; }
-      thead { display:none; }
-      tr { margin-bottom:10px; border:1px solid var(--border); border-radius:10px; overflow:hidden; }
-      td { display:flex; justify-content: space-between; align-items:center; padding:10px; }
-      td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
-      .checkbox { justify-content:flex-end; }
+      table { min-width: 720px; }
+      th, td { font-size:0.82rem; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- hide the d2ha_server container from the autodiscovery preferences table
- expose a public helper for reusing self-container detection logic in the UI
- keep autodiscovery checkboxes in a horizontal table layout on small screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fe8c817a48331a3758a9f1a6b1279)