### PR TITLE
Adjust autodiscovery checkbox layout

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -40,6 +40,9 @@
     tr:last-child td { border-bottom:none; }
     tr:nth-child(even) td { background: rgba(255,255,255,0.01); }
     .checkbox { display:flex; justify-content:center; align-items:center; }
+    .checkbox-row { display:flex; align-items:center; justify-content:center; gap:10px; flex-wrap:wrap; }
+    .checkbox-item { display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.03); }
+    .checkbox-item span { font-size:0.82rem; color: var(--muted); font-weight:700; letter-spacing:0.04em; text-transform: uppercase; }
     .checkbox input { width:18px; height:18px; accent-color: var(--accent); }
     .name { font-weight:700; }
     .muted { color: var(--muted); font-size:0.85rem; }
@@ -109,11 +112,21 @@
                     <td data-label="Immagine">{{ c.image }}</td>
                     <td data-label="Stato">{{ c.status }}</td>
                     <td data-label="Autodiscovery stato" class="checkbox">
-                      <input type="checkbox" name="{{ c.stable_id }}_state" {% if pref.state %}checked{% endif %} />
+                      <div class="checkbox-row">
+                        <label class="checkbox-item">
+                          <input type="checkbox" name="{{ c.stable_id }}_state" {% if pref.state %}checked{% endif %} />
+                          <span>Stato</span>
+                        </label>
+                      </div>
                     </td>
                     {% for action in actions %}
                       <td data-label="{{ action.replace('_', ' ')|title }}" class="checkbox">
-                        <input type="checkbox" name="{{ c.stable_id }}_{{ action }}" {% if pref.actions.get(action, True) %}checked{% endif %} />
+                        <div class="checkbox-row">
+                          <label class="checkbox-item">
+                            <input type="checkbox" name="{{ c.stable_id }}_{{ action }}" {% if pref.actions.get(action, True) %}checked{% endif %} />
+                            <span>{{ action.replace('_', ' ')|title }}</span>
+                          </label>
+                        </div>
                       </td>
                     {% endfor %}
                   </tr>


### PR DESCRIPTION
## Summary
- add horizontal flex styling to autodiscovery checkboxes
- wrap state and action checkboxes with labels so they align inline instead of stacking

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fea50373483319c193253c451b50d)