### PR TITLE
Add system events log page

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -162,6 +162,27 @@ def images_view():
     )
 
 
+@app.route("/events", methods=["GET"])
+def events_view():
+    hours_param = request.args.get("hours", default="24")
+    try:
+        hours = int(hours_param)
+    except ValueError:
+        hours = 24
+
+    hours = max(1, min(hours, 24 * 30))
+    events = docker_service.list_events(since_seconds=hours * 3600, limit=400)
+    stacks, summary = _build_home_context()
+
+    return render_template(
+        "events.html",
+        events=events,
+        selected_hours=hours,
+        summary=summary,
+        active_page="events",
+    )
+
+
 @app.route("/updates", methods=["GET"])
 def updates():
     containers_info = docker_service.collect_containers_info_for_updates()

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -71,6 +71,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -122,6 +122,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA – Eventi</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #151924;
+      --panel-2: #1b2131;
+      --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --text: #e7ecf4;
+      --muted: #9aa7bd;
+      --border: rgba(255,255,255,0.08);
+      --shadow: 0 10px 30px rgba(0,0,0,0.45);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at 10% 20%, rgba(0,255,255,0.05), transparent 25%),
+                  radial-gradient(circle at 90% 10%, rgba(124,255,195,0.05), transparent 20%),
+                  var(--bg);
+      color: var(--text);
+    }
+    a { color: inherit; text-decoration: none; }
+    header {
+      background: linear-gradient(90deg, #0d111c, #12182a);
+      border-bottom: 1px solid var(--border);
+      padding: 16px 22px 12px;
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      box-shadow: var(--shadow);
+    }
+    .brand-line { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
+    .brand-line h1 { margin:0; font-size:1.1rem; letter-spacing:0.1em; text-transform:uppercase; }
+    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
+    nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
+    .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
+    .tab:hover { color: var(--text); border-color: var(--border); }
+    .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    main { padding: 18px; display: flex; flex-direction: column; gap: 14px; }
+    .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
+    .filters { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
+    .select, .input { background: #0f141f; color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
+    .btn { border:none; border-radius:10px; padding:9px 14px; font-weight:700; cursor:pointer; background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .table-card { padding:0; overflow:hidden; }
+    .table-head { display:flex; justify-content:space-between; align-items:center; padding:14px 16px; border-bottom:1px solid var(--border); background: rgba(255,255,255,0.02); flex-wrap:wrap; gap:10px; }
+    table { width:100%; border-collapse: collapse; }
+    th, td { padding:10px 12px; text-align:left; font-size:0.85rem; border-bottom:1px solid var(--border); }
+    th { color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
+    tr:last-child td { border-bottom:none; }
+    tr:hover { background: rgba(255,255,255,0.03); }
+    .sev-pill { display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; font-weight:700; text-transform: uppercase; font-size:0.75rem; }
+    .sev-dot { width:10px; height:10px; border-radius:50%; display:inline-block; }
+    .sev-info { background: rgba(49,196,255,0.12); color: #31c4ff; }
+    .sev-info .sev-dot { background:#31c4ff; }
+    .sev-error { background: rgba(255,138,122,0.15); color: #ff8a7a; }
+    .sev-error .sev-dot { background:#ff8a7a; }
+    .meta { color: var(--muted); font-size:0.9rem; }
+    .muted { color: var(--muted); font-size:0.85rem; }
+    .badge { padding:4px 8px; border-radius:8px; background: rgba(255,255,255,0.05); border:1px solid var(--border); font-size:0.8rem; }
+    .empty { padding:18px; text-align:center; color: var(--muted); }
+    @media (max-width: 960px) {
+      table, thead, tbody, th, td, tr { display:block; }
+      thead { display:none; }
+      tr { margin-bottom:10px; border:1px solid var(--border); border-radius:10px; overflow:hidden; }
+      td { display:flex; justify-content: space-between; border-bottom:1px solid var(--border); }
+      td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="brand-line">
+      <h1>D2HA <span class="brand-pill">Eventi</span></h1>
+    </div>
+    <nav>
+      <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+      <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
+      <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
+      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
+      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+    </nav>
+  </header>
+
+  <main>
+    <section class="card filters">
+      <div class="meta">Ultimi eventi Docker del nodo {{ summary.cpu_count }} CPU · {{ summary.running }} container attivi</div>
+      <form method="get" class="filters" aria-label="Filtri eventi">
+        <label>
+          <span class="muted">Intervallo</span><br />
+          <select name="hours" class="select">
+            {% for opt in [1,6,12,24,72,168] %}
+              <option value="{{ opt }}" {% if selected_hours == opt %}selected{% endif %}>Ultime {{ opt }} ore</option>
+            {% endfor %}
+          </select>
+        </label>
+        <button class="btn" type="submit">Aggiorna</button>
+      </form>
+    </section>
+
+    <section class="card table-card">
+      <div class="table-head">
+        <div>
+          <div class="meta">{{ events|length }} eventi trovati</div>
+          <div class="muted">Host: {{ events[0].host if events else '-' }}</div>
+        </div>
+        <div class="badge">{{ selected_hours }}h di cronologia</div>
+      </div>
+      <table aria-label="Registro eventi di sistema">
+        <thead>
+          <tr>
+            <th>Data</th>
+            <th>Categoria</th>
+            <th>Severità</th>
+            <th>Dettagli evento</th>
+            <th>Container</th>
+            <th>Host</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% if events %}
+            {% for ev in events %}
+              <tr>
+                <td data-label="Data">{{ ev.timestamp_local.strftime('%d/%m/%Y %H:%M:%S') }}</td>
+                <td data-label="Categoria">{{ ev.type|title }}</td>
+                <td data-label="Severità">
+                  <span class="sev-pill {% if ev.severity == 'error' %}sev-error{% else %}sev-info{% endif %}">
+                    <span class="sev-dot"></span>{{ ev.severity|title }}
+                  </span>
+                </td>
+                <td data-label="Dettagli">
+                  <div>{{ ev.detail }}</div>
+                  <div class="muted">{{ ev.source }}</div>
+                </td>
+                <td data-label="Container">{{ ev.name }} <span class="muted">({{ ev.id }})</span></td>
+                <td data-label="Host">{{ ev.host }}</td>
+              </tr>
+            {% endfor %}
+          {% else %}
+            <tr>
+              <td colspan="6" class="empty">Nessun evento disponibile per l'intervallo selezionato.</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -295,6 +295,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -60,6 +60,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -71,6 +71,7 @@
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">Container</a>
       <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">Immagini</a>
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
+      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- capture recent Docker daemon events with host details and severity mapping
- expose a new /events route that renders the system event log with range filtering
- add an Eventi navigation tab across the UI and provide a dedicated event table view

## Testing
- python -m compileall d2ha

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692050c070fc832d95a438dd9a172cfb)