### PR TITLE
Make notifications available across all pages

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -208,8 +208,13 @@ def index():
 @app.route("/containers", methods=["GET"])
 def containers_view():
     stacks, summary = _build_home_context()
+    notifications = _build_notifications_summary()
     return render_template(
-        "containers.html", stacks=stacks, summary=summary, active_page="containers"
+        "containers.html",
+        stacks=stacks,
+        summary=summary,
+        notifications=notifications,
+        active_page="containers",
     )
 
 
@@ -217,8 +222,13 @@ def containers_view():
 def images_view():
     images = docker_service.list_images_overview()
     stacks, summary = _build_home_context()
+    notifications = _build_notifications_summary()
     return render_template(
-        "images.html", images=images, summary=summary, active_page="images"
+        "images.html",
+        images=images,
+        summary=summary,
+        notifications=notifications,
+        active_page="images",
     )
 
 
@@ -233,12 +243,14 @@ def events_view():
     hours = max(1, min(hours, 24 * 30))
     events = docker_service.list_events(since_seconds=hours * 3600, limit=400)
     stacks, summary = _build_home_context()
+    notifications = _build_notifications_summary()
 
     return render_template(
         "events.html",
         events=events,
         selected_hours=hours,
         summary=summary,
+        notifications=notifications,
         active_page="events",
     )
 
@@ -257,10 +269,12 @@ def updates():
         for name in sorted(stack_map.keys())
     ]
     stacks, summary = _build_home_context()
+    notifications = _build_notifications_summary()
     return render_template(
         "updates.html",
         stacks=grouped_containers,
         summary=summary,
+        notifications=notifications,
         active_page="updates",
     )
 
@@ -297,6 +311,7 @@ def autodiscovery_view():
 
     pref_map = autodiscovery_preferences.build_map_for(stable_ids)
     stacks, summary = _build_home_context()
+    notifications = _build_notifications_summary()
 
     return render_template(
         "autodiscovery.html",
@@ -304,6 +319,7 @@ def autodiscovery_view():
         preferences=pref_map,
         actions=AutodiscoveryPreferences.AVAILABLE_ACTIONS,
         summary=summary,
+        notifications=notifications,
         active_page="autodiscovery",
     )
 

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -60,11 +60,13 @@
       th, td { font-size:0.82rem; }
     }
   </style>
+  {% include 'partials/notifications_styles.html' %}
 </head>
 <body>
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Autodiscovery</span></h1>
+      {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
@@ -141,6 +143,7 @@
       {% endfor %}
     </form>
   </main>
+  {% include 'partials/notifications_script.html' %}
   <script>
     document.querySelectorAll('.deselect-stack').forEach((button) => {
       button.addEventListener('click', () => {

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -111,11 +111,13 @@
       td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
     }
   </style>
+  {% include 'partials/notifications_styles.html' %}
 </head>
 <body>
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Container</span></h1>
+      {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
@@ -375,6 +377,7 @@
     </div>
   </div>
   <div class="toast-container" id="toast-container"></div>
+  {% include 'partials/notifications_script.html' %}
   <script>
     const modalEl = document.getElementById('container-modal');
     const modalTitle = document.getElementById('modal-title');

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -72,11 +72,13 @@
       td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
     }
   </style>
+  {% include 'partials/notifications_styles.html' %}
 </head>
 <body>
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Eventi</span></h1>
+      {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
@@ -151,5 +153,6 @@
       </table>
     </section>
   </main>
+  {% include 'partials/notifications_script.html' %}
 </body>
 </html>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -60,136 +60,6 @@
       font-size: 0.8rem;
       letter-spacing: 0.04em;
     }
-    .notif-area {
-      position: relative;
-      margin-left: auto;
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .notif-toggle {
-      position: relative;
-      background: rgba(255,255,255,0.05);
-      border: 1px solid var(--border);
-      color: var(--text);
-      border-radius: 10px;
-      padding: 8px 12px;
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
-    .notif-toggle:hover { border-color: rgba(49,196,255,0.5); }
-    .notif-icon {
-      width: 16px;
-      height: 16px;
-      position: relative;
-      display: inline-block;
-    }
-    .notif-icon::before,
-    .notif-icon::after {
-      content: "";
-      position: absolute;
-      background: currentColor;
-      left: 50%;
-      transform: translateX(-50%);
-    }
-    .notif-icon::before {
-      width: 16px;
-      height: 14px;
-      border-radius: 8px 8px 4px 4px;
-      border: 2px solid currentColor;
-      border-bottom-width: 4px;
-      background: transparent;
-      box-sizing: border-box;
-      top: 0;
-    }
-    .notif-icon::after {
-      width: 6px;
-      height: 6px;
-      border-radius: 50%;
-      bottom: -6px;
-    }
-    .notif-badge {
-      min-width: 20px;
-      height: 20px;
-      border-radius: 999px;
-      background: linear-gradient(135deg, #ff8a7a, #ff5f6d);
-      color: #0c121e;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      font-weight: 800;
-      font-size: 0.8rem;
-      padding: 0 6px;
-      box-shadow: 0 4px 12px rgba(255,99,71,0.35);
-    }
-    .notif-panel {
-      position: absolute;
-      right: 0;
-      top: 44px;
-      width: min(360px, 90vw);
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 14px;
-      box-shadow: var(--shadow);
-      display: none;
-      flex-direction: column;
-      overflow: hidden;
-      z-index: 20;
-    }
-    .notif-panel.open { display: flex; }
-    .notif-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 12px 14px;
-      border-bottom: 1px solid var(--border);
-      font-weight: 700;
-    }
-    .notif-list {
-      max-height: 320px;
-      overflow-y: auto;
-      display: flex;
-      flex-direction: column;
-    }
-    .notif-item {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-      padding: 10px 14px;
-      border-bottom: 1px solid rgba(255,255,255,0.05);
-      background: rgba(255,255,255,0.02);
-    }
-    .notif-item:last-child { border-bottom: none; }
-    .notif-content { flex: 1; min-width: 0; }
-    .notif-title { font-weight: 700; font-size: 0.95rem; }
-    .notif-desc { color: var(--muted); font-size: 0.85rem; }
-    .notif-dismiss {
-      border: none;
-      background: rgba(255,255,255,0.06);
-      color: var(--muted);
-      width: 28px;
-      height: 28px;
-      border-radius: 50%;
-      cursor: pointer;
-      transition: all 0.15s ease;
-    }
-    .notif-dismiss:hover {
-      color: var(--text);
-      background: rgba(255,99,71,0.18);
-      border: 1px solid rgba(255,99,71,0.35);
-    }
-    .notif-empty { padding: 14px; color: var(--muted); text-align: center; }
-    .notif-pill {
-      padding: 4px 8px;
-      background: rgba(255,255,255,0.06);
-      border-radius: 999px;
-      font-size: 0.78rem;
-      color: var(--muted);
-      margin-left: auto;
-    }
     nav {
       margin-top: 10px;
       display: flex;
@@ -414,24 +284,13 @@
     }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  {% include 'partials/notifications_styles.html' %}
 </head>
   <body>
     <header>
       <div class="brand-line">
         <h1>D2HA <span class="brand-pill">Webserver</span></h1>
-        <div class="notif-area">
-          <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
-            <span class="notif-icon" aria-hidden="true"></span>
-            <span class="notif-badge" id="notifBadge">0</span>
-          </button>
-          <div class="notif-panel" id="notifPanel" role="region" aria-label="Notifiche">
-            <div class="notif-header">
-              <span>Notifiche</span>
-              <span class="notif-pill" id="notifHint">Swipe o tocca la X per ignorare</span>
-            </div>
-            <div class="notif-list" id="notifList"></div>
-          </div>
-        </div>
+        {% include 'partials/notifications_panel.html' %}
       </div>
       <nav>
         <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
@@ -560,194 +419,14 @@
     </main>
   </div>
 
+  {% include 'partials/notifications_script.html' %}
+
   <script>
     const initialData = {{ {"summary": summary, "stacks": stacks}|tojson }};
-    const initialNotifications = {{ notifications|tojson }};
 
     Chart.defaults.devicePixelRatio = Math.max(window.devicePixelRatio || 1, 2);
     Chart.defaults.font.family = 'Inter, system-ui, -apple-system, "Segoe UI", sans-serif';
     Chart.defaults.font.weight = '600';
-
-    const notifListEl = document.getElementById('notifList');
-    const notifBadgeEl = document.getElementById('notifBadge');
-    const notifPanelEl = document.getElementById('notifPanel');
-    const notifToggleEl = document.getElementById('notifToggle');
-    let currentNotifications = initialNotifications || {};
-    let dismissedNotifications = {};
-
-    function loadDismissedNotifications() {
-      try {
-        dismissedNotifications = JSON.parse(localStorage.getItem('d2haDismissedNotifications') || '{}') || {};
-      } catch (err) {
-        dismissedNotifications = {};
-      }
-    }
-
-    function saveDismissedNotifications() {
-      localStorage.setItem('d2haDismissedNotifications', JSON.stringify(dismissedNotifications));
-    }
-
-    function shouldIgnoreNotification(item) {
-      const entry = dismissedNotifications[item.id];
-      return entry && entry.count >= item.count;
-    }
-
-    function updateBadge(count) {
-      if (!notifBadgeEl) return;
-      if (count > 0) {
-        notifBadgeEl.textContent = count;
-        notifBadgeEl.style.visibility = 'visible';
-      } else {
-        notifBadgeEl.textContent = '0';
-        notifBadgeEl.style.visibility = 'hidden';
-      }
-    }
-
-    function dismissNotification(item) {
-      dismissedNotifications[item.id] = { count: item.count, ts: Date.now() };
-      saveDismissedNotifications();
-      renderNotificationList(currentNotifications);
-    }
-
-    function attachSwipeToDismiss(element, item) {
-      let touchStartX = null;
-      element.addEventListener('touchstart', (ev) => {
-        touchStartX = ev.changedTouches[0]?.clientX || 0;
-      });
-      element.addEventListener('touchend', (ev) => {
-        if (touchStartX === null) return;
-        const delta = (ev.changedTouches[0]?.clientX || 0) - touchStartX;
-        if (Math.abs(delta) > 45) {
-          dismissNotification(item);
-        }
-        touchStartX = null;
-      });
-    }
-
-    function buildNotificationItems(data) {
-      const items = [];
-      const unused = data?.unused_images || {};
-      if (unused.count > 0) {
-        items.push({
-          id: 'unused-images',
-          count: unused.count,
-          title: 'Immagini non utilizzate',
-          description: `${unused.count} immagini · Spazio liberabile: ${unused.reclaimable_h || '-'}`,
-        });
-      }
-
-      if ((data?.updates_pending || 0) > 0) {
-        const count = data.updates_pending;
-        items.push({
-          id: 'updates-pending',
-          count,
-          title: 'Container da aggiornare',
-          description: `${count} container non ancora aggiornati`,
-        });
-      }
-
-      if ((data?.critical_events || 0) > 0) {
-        const count = data.critical_events;
-        items.push({
-          id: 'critical-events',
-          count,
-          title: 'Eventi critici',
-          description: `${count} eventi critici o fatali registrati (ultime 24h)`,
-        });
-      }
-
-      return items;
-    }
-
-    function renderNotificationList(data) {
-      currentNotifications = data || {};
-      const items = buildNotificationItems(currentNotifications);
-      const visible = items.filter((item) => !shouldIgnoreNotification(item));
-
-      if (!notifListEl) return;
-      notifListEl.innerHTML = '';
-
-      if (visible.length === 0) {
-        const empty = document.createElement('div');
-        empty.className = 'notif-empty';
-        empty.textContent = 'Nessuna notifica al momento';
-        notifListEl.appendChild(empty);
-        updateBadge(0);
-        return;
-      }
-
-      visible.forEach((item) => {
-        const row = document.createElement('div');
-        row.className = 'notif-item';
-        row.dataset.id = item.id;
-
-        const content = document.createElement('div');
-        content.className = 'notif-content';
-
-        const title = document.createElement('div');
-        title.className = 'notif-title';
-        title.textContent = item.title;
-
-        const desc = document.createElement('div');
-        desc.className = 'notif-desc';
-        desc.textContent = item.description;
-
-        content.appendChild(title);
-        content.appendChild(desc);
-
-        const dismissBtn = document.createElement('button');
-        dismissBtn.className = 'notif-dismiss';
-        dismissBtn.type = 'button';
-        dismissBtn.setAttribute('aria-label', 'Ignora notifica');
-        dismissBtn.textContent = '×';
-        dismissBtn.addEventListener('click', (ev) => {
-          ev.stopPropagation();
-          dismissNotification(item);
-        });
-
-        row.appendChild(content);
-        row.appendChild(dismissBtn);
-        attachSwipeToDismiss(row, item);
-        notifListEl.appendChild(row);
-      });
-
-      updateBadge(visible.length);
-    }
-
-    function toggleNotifications(open = null) {
-      if (!notifPanelEl || !notifToggleEl) return;
-      const shouldOpen = open === null ? !notifPanelEl.classList.contains('open') : open;
-      notifPanelEl.classList.toggle('open', shouldOpen);
-      notifToggleEl.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
-    }
-
-    function setupNotificationToggle() {
-      if (!notifToggleEl) return;
-      notifToggleEl.addEventListener('click', (ev) => {
-        ev.stopPropagation();
-        toggleNotifications();
-      });
-
-      document.addEventListener('click', (ev) => {
-        if (!notifPanelEl || !notifToggleEl) return;
-        const target = ev.target;
-        if (notifPanelEl.contains(target) || notifToggleEl.contains(target)) {
-          return;
-        }
-        toggleNotifications(false);
-      });
-    }
-
-    async function refreshNotifications() {
-      try {
-        const res = await fetch('/api/notifications');
-        if (!res.ok) return;
-        const data = await res.json();
-        renderNotificationList(data);
-      } catch (err) {
-        console.error('Failed to refresh notifications', err);
-      }
-    }
 
     const gridColor = 'rgba(255,255,255,0.06)';
     const tickColor = '#a8b5cb';
@@ -1026,11 +705,6 @@
         console.error('Failed to refresh overview', err);
       }
     }
-
-    loadDismissedNotifications();
-    renderNotificationList(initialNotifications);
-    setupNotificationToggle();
-    setInterval(refreshNotifications, 15000);
 
     applySummary(initialData.summary);
     applyStacks(initialData.stacks);

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -49,11 +49,13 @@
       td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
     }
   </style>
+  {% include 'partials/notifications_styles.html' %}
 </head>
 <body>
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Immagini</span></h1>
+      {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
@@ -109,5 +111,6 @@
       </table>
     </section>
   </main>
+  {% include 'partials/notifications_script.html' %}
 </body>
 </html>

--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -1,0 +1,12 @@
+<div class="notif-area">
+  <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
+    <span class="notif-icon" aria-hidden="true"></span>
+    <span class="notif-badge" id="notifBadge">0</span>
+  </button>
+  <div class="notif-panel" id="notifPanel" role="region" aria-label="Notifiche">
+    <div class="notif-header">
+      <span>Notifiche</span>
+    </div>
+    <div class="notif-list" id="notifList"></div>
+  </div>
+</div>

--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -1,0 +1,191 @@
+<script>
+(() => {
+  const initialNotifications = {{ notifications|default({})|tojson }} || {};
+  const notifListEl = document.getElementById('notifList');
+  const notifBadgeEl = document.getElementById('notifBadge');
+  const notifPanelEl = document.getElementById('notifPanel');
+  const notifToggleEl = document.getElementById('notifToggle');
+  let currentNotifications = initialNotifications;
+  let dismissedNotifications = {};
+
+  function loadDismissedNotifications() {
+    try {
+      dismissedNotifications = JSON.parse(localStorage.getItem('d2haDismissedNotifications') || '{}') || {};
+    } catch (err) {
+      dismissedNotifications = {};
+    }
+  }
+
+  function saveDismissedNotifications() {
+    localStorage.setItem('d2haDismissedNotifications', JSON.stringify(dismissedNotifications));
+  }
+
+  function shouldIgnoreNotification(item) {
+    const entry = dismissedNotifications[item.id];
+    return entry && entry.count >= item.count;
+  }
+
+  function updateBadge(count) {
+    if (!notifBadgeEl) return;
+    if (count > 0) {
+      notifBadgeEl.textContent = count;
+      notifBadgeEl.style.visibility = 'visible';
+    } else {
+      notifBadgeEl.textContent = '0';
+      notifBadgeEl.style.visibility = 'hidden';
+    }
+  }
+
+  function dismissNotification(item) {
+    dismissedNotifications[item.id] = { count: item.count, ts: Date.now() };
+    saveDismissedNotifications();
+    renderNotificationList(currentNotifications);
+  }
+
+  function attachSwipeToDismiss(element, item) {
+    let touchStartX = null;
+    element.addEventListener('touchstart', (ev) => {
+      touchStartX = ev.changedTouches[0]?.clientX || 0;
+    });
+    element.addEventListener('touchend', (ev) => {
+      if (touchStartX === null) return;
+      const delta = (ev.changedTouches[0]?.clientX || 0) - touchStartX;
+      if (Math.abs(delta) > 45) {
+        dismissNotification(item);
+      }
+      touchStartX = null;
+    });
+  }
+
+  function buildNotificationItems(data) {
+    const items = [];
+    const unused = data?.unused_images || {};
+    if (unused.count > 0) {
+      items.push({
+        id: 'unused-images',
+        count: unused.count,
+        title: 'Immagini non utilizzate',
+        description: `${unused.count} immagini · Spazio liberabile: ${unused.reclaimable_h || '-'}`,
+      });
+    }
+
+    if ((data?.updates_pending || 0) > 0) {
+      const count = data.updates_pending;
+      items.push({
+        id: 'updates-pending',
+        count,
+        title: 'Container da aggiornare',
+        description: `${count} container non ancora aggiornati`,
+      });
+    }
+
+    if ((data?.critical_events || 0) > 0) {
+      const count = data.critical_events;
+      items.push({
+        id: 'critical-events',
+        count,
+        title: 'Eventi critici',
+        description: `${count} eventi critici o fatali registrati (ultime 24h)`,
+      });
+    }
+
+    return items;
+  }
+
+  function renderNotificationList(data) {
+    currentNotifications = data || {};
+    const items = buildNotificationItems(currentNotifications);
+    const visible = items.filter((item) => !shouldIgnoreNotification(item));
+
+    if (!notifListEl) return;
+    notifListEl.innerHTML = '';
+
+    if (visible.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'notif-empty';
+      empty.textContent = 'Nessuna notifica al momento';
+      notifListEl.appendChild(empty);
+      updateBadge(0);
+      return;
+    }
+
+    visible.forEach((item) => {
+      const row = document.createElement('div');
+      row.className = 'notif-item';
+      row.dataset.id = item.id;
+
+      const content = document.createElement('div');
+      content.className = 'notif-content';
+
+      const title = document.createElement('div');
+      title.className = 'notif-title';
+      title.textContent = item.title;
+
+      const desc = document.createElement('div');
+      desc.className = 'notif-desc';
+      desc.textContent = item.description;
+
+      content.appendChild(title);
+      content.appendChild(desc);
+
+      const dismissBtn = document.createElement('button');
+      dismissBtn.className = 'notif-dismiss';
+      dismissBtn.type = 'button';
+      dismissBtn.setAttribute('aria-label', 'Ignora notifica');
+      dismissBtn.textContent = '×';
+      dismissBtn.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        dismissNotification(item);
+      });
+
+      row.appendChild(content);
+      row.appendChild(dismissBtn);
+      attachSwipeToDismiss(row, item);
+      notifListEl.appendChild(row);
+    });
+
+    updateBadge(visible.length);
+  }
+
+  function toggleNotifications(open = null) {
+    if (!notifPanelEl || !notifToggleEl) return;
+    const shouldOpen = open === null ? !notifPanelEl.classList.contains('open') : open;
+    notifPanelEl.classList.toggle('open', shouldOpen);
+    notifToggleEl.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+  }
+
+  function setupNotificationToggle() {
+    if (!notifToggleEl) return;
+    notifToggleEl.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      toggleNotifications();
+    });
+
+    document.addEventListener('click', (ev) => {
+      if (!notifPanelEl || !notifToggleEl) return;
+      const target = ev.target;
+      if (notifPanelEl.contains(target) || notifToggleEl.contains(target)) {
+        return;
+      }
+      toggleNotifications(false);
+    });
+  }
+
+  async function refreshNotifications() {
+    try {
+      const res = await fetch('/api/notifications');
+      if (!res.ok) return;
+      const data = await res.json();
+      renderNotificationList(data);
+    } catch (err) {
+      console.error('Failed to refresh notifications', err);
+    }
+  }
+
+  loadDismissedNotifications();
+  renderNotificationList(currentNotifications);
+  setupNotificationToggle();
+  refreshNotifications();
+  setInterval(refreshNotifications, 60000);
+})();
+</script>

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -1,0 +1,125 @@
+<style>
+  .notif-area {
+    position: relative;
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .notif-toggle {
+    position: relative;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 8px 12px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    box-shadow: var(--shadow);
+  }
+  .notif-toggle:hover { border-color: rgba(49,196,255,0.5); }
+  .notif-icon {
+    width: 16px;
+    height: 16px;
+    position: relative;
+    display: inline-block;
+  }
+  .notif-icon::before,
+  .notif-icon::after {
+    content: "";
+    position: absolute;
+    background: currentColor;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .notif-icon::before {
+    width: 16px;
+    height: 14px;
+    border-radius: 8px 8px 4px 4px;
+    border: 2px solid currentColor;
+    border-bottom-width: 4px;
+    background: transparent;
+    box-sizing: border-box;
+    top: 0;
+  }
+  .notif-icon::after {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    bottom: -6px;
+  }
+  .notif-badge {
+    min-width: 20px;
+    height: 20px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #ff8a7a, #ff5f6d);
+    color: #0c121e;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    font-size: 0.8rem;
+    padding: 0 6px;
+    box-shadow: 0 4px 12px rgba(255,99,71,0.35);
+  }
+  .notif-panel {
+    position: absolute;
+    right: 0;
+    top: 44px;
+    width: min(360px, 90vw);
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    box-shadow: var(--shadow);
+    display: none;
+    flex-direction: column;
+    overflow: hidden;
+    z-index: 20;
+  }
+  .notif-panel.open { display: flex; }
+  .notif-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    font-weight: 700;
+    gap: 10px;
+  }
+  .notif-list {
+    max-height: 320px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+  .notif-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+    background: rgba(255,255,255,0.02);
+  }
+  .notif-item:last-child { border-bottom: none; }
+  .notif-content { flex: 1; min-width: 0; }
+  .notif-title { font-weight: 700; font-size: 0.95rem; }
+  .notif-desc { color: var(--muted); font-size: 0.85rem; }
+  .notif-dismiss {
+    border: none;
+    background: rgba(255,255,255,0.06);
+    color: var(--muted);
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    cursor: pointer;
+    transition: all 0.15s ease;
+  }
+  .notif-dismiss:hover {
+    color: var(--text);
+    background: rgba(255,99,71,0.18);
+    border: 1px solid rgba(255,99,71,0.35);
+  }
+  .notif-empty { padding: 14px; color: var(--muted); text-align: center; }
+</style>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -77,11 +77,13 @@
       td::before { content: attr(data-label); font-weight: 700; color: var(--muted); margin-right: 10px; }
     }
   </style>
+  {% include 'partials/notifications_styles.html' %}
 </head>
 <body>
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Aggiornamenti</span></h1>
+      {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
@@ -211,6 +213,7 @@
     </div>
   </div>
 
+  {% include 'partials/notifications_script.html' %}
   <script>
     const statusClasses = {
       update_available: 'status-update-available',


### PR DESCRIPTION
## Summary
- add shared notification dropdown partials used across all pages
- remove the dismiss hint and reuse shared scripts/styles for notifications
- wire notification data into every view

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69205c8f9418832d88a9d4c283e4430d)