### PR TITLE
Add warning filtering and update stack headings

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -243,7 +243,7 @@ def events_view():
 
     hours = max(1, min(hours, 24 * 30))
     events = docker_service.list_events(since_seconds=hours * 3600, limit=400)
-    allowed_severities = {"all", "info", "error"}
+    allowed_severities = {"all", "info", "warning", "error"}
     selected_severity = severity_param if severity_param in allowed_severities else "all"
     if selected_severity != "all":
         events = [ev for ev in events if ev.get("severity") == selected_severity]

--- a/d2ha/docker_service.py
+++ b/d2ha/docker_service.py
@@ -600,8 +600,13 @@ class DockerService:
 
     def _severity_from_action(self, action: str) -> str:
         action_l = (action or "").lower()
-        if action_l in {"die", "oom", "kill", "destroy", "stop"}:
+        error_actions = {"die", "oom", "kill", "destroy", "stop"}
+        warning_actions = {"restart", "pause", "unpause", "health_status", "update"}
+
+        if action_l in error_actions:
             return "error"
+        if action_l in warning_actions:
+            return "warning"
         return "info"
 
     def _format_event_entry(self, raw_event: Dict[str, Any]) -> Optional[Dict[str, Any]]:

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -100,9 +100,8 @@
         <section class="stack">
           <div class="stack-header stack-toggle" data-stack-toggle>
             <div class="stack-title">
-              <button type="button" class="stack-toggle-btn" aria-expanded="true" aria-label="Mostra o nascondi stack">
+              <button type="button" class="stack-toggle-btn" aria-expanded="true" aria-label="Mostra o nascondi sezione">
                 <span class="chevron">▾</span>
-                Stack
               </button>
               <span>{{ 'Senza stack' if stack == '_no_stack' else stack }}</span>
             </div>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -143,9 +143,8 @@
       <section class="card">
         <div class="stack-header stack-toggle" data-stack-toggle>
           <div class="stack-title">
-            <button class="stack-toggle-btn" type="button" aria-expanded="true" aria-label="Mostra o nascondi stack">
+            <button class="stack-toggle-btn" type="button" aria-expanded="true" aria-label="Mostra o nascondi sezione">
               <span class="chevron">▾</span>
-              Stack
             </button>
             <span>{{ 'Senza stack' if stack.name == '_no_stack' else stack.name }}</span>
           </div>

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -58,6 +58,8 @@
     .sev-dot { width:10px; height:10px; border-radius:50%; display:inline-block; }
     .sev-info { background: rgba(49,196,255,0.12); color: #31c4ff; }
     .sev-info .sev-dot { background:#31c4ff; }
+    .sev-warning { background: rgba(255,213,79,0.16); color: #ffd54f; }
+    .sev-warning .sev-dot { background:#ffd54f; }
     .sev-error { background: rgba(255,138,122,0.15); color: #ff8a7a; }
     .sev-error .sev-dot { background:#ff8a7a; }
     .meta { color: var(--muted); font-size:0.9rem; }
@@ -106,6 +108,7 @@
           <select name="severity" class="select">
             <option value="all" {% if selected_severity == 'all' %}selected{% endif %}>Tutte</option>
             <option value="info" {% if selected_severity == 'info' %}selected{% endif %}>Info</option>
+            <option value="warning" {% if selected_severity == 'warning' %}selected{% endif %}>Warning</option>
             <option value="error" {% if selected_severity == 'error' %}selected{% endif %}>Errori</option>
           </select>
         </label>
@@ -139,7 +142,7 @@
                 <td data-label="Data">{{ ev.timestamp_local.strftime('%d/%m/%Y %H:%M:%S') }}</td>
                 <td data-label="Categoria">{{ ev.type|title }}</td>
                 <td data-label="Severità">
-                  <span class="sev-pill {% if ev.severity == 'error' %}sev-error{% else %}sev-info{% endif %}">
+                  <span class="sev-pill {% if ev.severity == 'error' %}sev-error{% elif ev.severity == 'warning' %}sev-warning{% else %}sev-info{% endif %}">
                     <span class="sev-dot"></span>{{ ev.severity|title }}
                   </span>
                 </td>


### PR DESCRIPTION
## Summary
- add warning severity styling and filtering to the events view
- classify additional Docker actions as warning severity
- remove the visible "Stack" label beside stack names in containers and autodiscovery pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692063d36db8832dbfc3794b95aed0db)