### PR TITLE
Add settings dropdown and safe mode controls

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -61,6 +61,9 @@
     .btn-secondary { background: rgba(255,255,255,0.06); border:1px solid var(--border); color: var(--text); border-radius:12px; padding:8px 12px; font-weight:700; cursor:pointer; transition: all 0.15s ease; }
     .btn-secondary:hover { border-color: rgba(49,196,255,0.5); color: var(--accent); }
     .note { background: rgba(49,196,255,0.08); border:1px solid rgba(49,196,255,0.25); padding:10px 12px; border-radius:12px; font-size:0.9rem; }
+    .safe-locked .checkbox-item { opacity: 0.45; pointer-events: none; }
+    .safe-locked .checkbox input { pointer-events: none; }
+    .safe-locked .btn-secondary { opacity: 0.45; cursor: not-allowed; pointer-events: none; }
     @media(max-width: 960px) {
       table { min-width: 720px; }
       th, td { font-size:0.82rem; }
@@ -68,7 +71,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body>
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Autodiscovery</span></h1>
@@ -156,6 +159,8 @@
   {% include 'partials/notifications_script.html' %}
   <script>
     const stackToggles = Array.from(document.querySelectorAll('[data-stack-toggle]'));
+    const deselectButtons = Array.from(document.querySelectorAll('.deselect-stack'));
+    const autodiscoveryForm = document.getElementById('autodiscovery-form');
     stackToggles.forEach((header) => {
       const btn = header.querySelector('.stack-toggle-btn');
       const content = header.nextElementSibling;
@@ -186,7 +191,7 @@
       });
     });
 
-    document.querySelectorAll('.deselect-stack').forEach((button) => {
+    deselectButtons.forEach((button) => {
       button.addEventListener('click', () => {
         const stackSection = button.closest('.stack');
         if (!stackSection) return;
@@ -195,6 +200,23 @@
           checkbox.checked = false;
         });
       });
+    });
+
+    function applySafeModeLock(enabled) {
+      if (!autodiscoveryForm) return;
+      autodiscoveryForm.classList.toggle('safe-locked', enabled);
+      autodiscoveryForm.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
+        checkbox.disabled = enabled;
+      });
+      deselectButtons.forEach((button) => {
+        button.disabled = enabled;
+      });
+    }
+
+    const initialSafeMode = window.d2haSafeMode?.enabled ?? ((document.body.dataset.safeMode || '0') === '1');
+    applySafeModeLock(initialSafeMode);
+    document.addEventListener('safe-mode-changed', (event) => {
+      applySafeModeLock(!!event.detail?.enabled);
     });
   </script>
 </body>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -118,7 +118,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body>
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Container</span></h1>
@@ -224,19 +224,19 @@
                       <form method="post" action="{{ url_for('container_action', container_id=c.id, action='play') }}">
                         <button class="btn btn-play" type="submit">Play</button>
                       </form>
-                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='pause') }}">
+                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='pause') }}" data-safe-confirm="Mettere in pausa {{ c.name }}?">
                         <button class="btn btn-pause" type="submit">Pausa</button>
                       </form>
-                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='stop') }}">
+                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='stop') }}" data-safe-confirm="Arrestare {{ c.name }}?">
                         <button class="btn btn-stop" type="submit">Stop</button>
                       </form>
-                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='restart') }}">
+                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='restart') }}" data-safe-confirm="Riavviare {{ c.name }}?">
                         <button class="btn btn-restart" type="submit">Riavvia</button>
                       </form>
                       <form method="post" action="{{ url_for('container_action', container_id=c.id, action='unpause') }}">
                         <button class="btn" type="submit">Riprendi</button>
                       </form>
-                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='delete') }}">
+                      <form method="post" action="{{ url_for('container_action', container_id=c.id, action='delete') }}" data-safe-confirm="Eliminare definitivamente {{ c.name }}?">
                         <button class="btn btn-delete" type="submit">Elimina</button>
                       </form>
                     </div>

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -76,7 +76,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body>
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Eventi</span></h1>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -286,7 +286,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   {% include 'partials/notifications_styles.html' %}
 </head>
-  <body>
+  <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
     <header>
       <div class="brand-line">
         <h1>D2HA <span class="brand-pill">Webserver</span></h1>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -51,7 +51,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body>
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Immagini</span></h1>
@@ -101,7 +101,7 @@
                 {% endif %}
               </td>
               <td data-label="Azioni">
-                <form method="post" action="{{ url_for('delete_image', image_id=img.id) }}">
+                <form method="post" action="{{ url_for('delete_image', image_id=img.id) }}" data-safe-confirm="Eliminare l'immagine {{ img.short_id }}?">
                   <button class="btn btn-danger" type="submit" {% if is_used %}disabled{% endif %}>Elimina</button>
                 </form>
               </td>

--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -1,12 +1,51 @@
-<div class="notif-area">
-  <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
-    <span class="notif-icon" aria-hidden="true"></span>
-    <span class="notif-badge" id="notifBadge">0</span>
-  </button>
-  <div class="notif-panel" id="notifPanel" role="region" aria-label="Notifiche">
-    <div class="notif-header">
-      <span>Notifiche</span>
+<div class="header-actions">
+  <div class="notif-area">
+    <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
+      <span class="notif-icon" aria-hidden="true">🔔</span>
+      <span class="notif-badge" id="notifBadge">0</span>
+    </button>
+    <div class="notif-panel" id="notifPanel" role="region" aria-label="Notifiche">
+      <div class="notif-header">
+        <span>Notifiche</span>
+      </div>
+      <div class="notif-list" id="notifList"></div>
     </div>
-    <div class="notif-list" id="notifList"></div>
+  </div>
+
+  <div class="settings-area">
+    <button class="settings-toggle" id="settingsToggle" aria-expanded="false" aria-controls="settingsPanel">
+      <span class="settings-icon" aria-hidden="true">⚙️</span>
+    </button>
+    <div class="settings-panel" id="settingsPanel" role="region" aria-label="Impostazioni">
+      <div class="settings-header">
+        <span>Impostazioni</span>
+      </div>
+      <div class="settings-body">
+        <div class="settings-row">
+          <span>OS installato</span>
+          <strong>{{ system_info.os }}</strong>
+        </div>
+        <div class="settings-row">
+          <span>Versione Docker</span>
+          <strong>{{ system_info.docker_version }}</strong>
+        </div>
+        <div class="settings-row">
+          <span>Uptime</span>
+          <strong>{{ system_info.uptime }}</strong>
+        </div>
+        <div class="settings-safe">
+          <div>
+            <div class="settings-row">
+              <span>Modalità sicura</span>
+              <div class="switch" title="Richiedi conferma per le operazioni sensibili">
+                <input type="checkbox" id="safeModeToggle" {% if safe_mode_enabled %}checked{% endif %} />
+                <span class="slider"></span>
+              </div>
+            </div>
+            <p class="settings-hint">Richiedi conferma o blocca le modifiche critiche.</p>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </div>

--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -5,8 +5,22 @@
   const notifBadgeEl = document.getElementById('notifBadge');
   const notifPanelEl = document.getElementById('notifPanel');
   const notifToggleEl = document.getElementById('notifToggle');
+  const settingsPanelEl = document.getElementById('settingsPanel');
+  const settingsToggleEl = document.getElementById('settingsToggle');
+  const safeModeToggleEl = document.getElementById('safeModeToggle');
+  let safeModeEnabled = (document.body.dataset.safeMode || '0') === '1';
   let currentNotifications = initialNotifications;
   let dismissedNotifications = {};
+
+  function updateSafeModeState(enabled) {
+    safeModeEnabled = !!enabled;
+    document.body.dataset.safeMode = safeModeEnabled ? '1' : '0';
+    if (safeModeToggleEl) {
+      safeModeToggleEl.checked = safeModeEnabled;
+    }
+    window.d2haSafeMode = { enabled: safeModeEnabled };
+    document.dispatchEvent(new CustomEvent('safe-mode-changed', { detail: { enabled: safeModeEnabled } }));
+  }
 
   function loadDismissedNotifications() {
     try {
@@ -152,6 +166,21 @@
     const shouldOpen = open === null ? !notifPanelEl.classList.contains('open') : open;
     notifPanelEl.classList.toggle('open', shouldOpen);
     notifToggleEl.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+    if (shouldOpen && settingsPanelEl) {
+      settingsPanelEl.classList.remove('open');
+      settingsToggleEl?.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  function toggleSettings(open = null) {
+    if (!settingsPanelEl || !settingsToggleEl) return;
+    const shouldOpen = open === null ? !settingsPanelEl.classList.contains('open') : open;
+    settingsPanelEl.classList.toggle('open', shouldOpen);
+    settingsToggleEl.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+    if (shouldOpen && notifPanelEl) {
+      notifPanelEl.classList.remove('open');
+      notifToggleEl?.setAttribute('aria-expanded', 'false');
+    }
   }
 
   function setupNotificationToggle() {
@@ -164,10 +193,24 @@
     document.addEventListener('click', (ev) => {
       if (!notifPanelEl || !notifToggleEl) return;
       const target = ev.target;
-      if (notifPanelEl.contains(target) || notifToggleEl.contains(target)) {
+      if (
+        notifPanelEl.contains(target) ||
+        notifToggleEl.contains(target) ||
+        settingsPanelEl?.contains(target) ||
+        settingsToggleEl?.contains(target)
+      ) {
         return;
       }
       toggleNotifications(false);
+      toggleSettings(false);
+    });
+  }
+
+  function setupSettingsToggle() {
+    if (!settingsToggleEl) return;
+    settingsToggleEl.addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      toggleSettings();
     });
   }
 
@@ -182,9 +225,55 @@
     }
   }
 
+  async function persistSafeMode(enabled) {
+    try {
+      const res = await fetch('/api/safe_mode', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const data = await res.json();
+      updateSafeModeState(!!data.enabled);
+    } catch (err) {
+      console.error('Impossibile aggiornare la modalità sicura', err);
+      if (safeModeToggleEl) {
+        safeModeToggleEl.checked = safeModeEnabled;
+      }
+      alert('Impossibile aggiornare la modalità sicura');
+    }
+  }
+
+  function setupSafeModeToggle() {
+    if (!safeModeToggleEl) return;
+    safeModeToggleEl.addEventListener('change', () => {
+      persistSafeMode(safeModeToggleEl.checked);
+    });
+  }
+
+  function setupSafeConfirmations() {
+    document.addEventListener(
+      'submit',
+      (ev) => {
+        const form = ev.target;
+        if (!(form instanceof HTMLFormElement)) return;
+        const message = form.dataset.safeConfirm;
+        if (!message || !safeModeEnabled) return;
+        if (!window.confirm(message)) {
+          ev.preventDefault();
+        }
+      },
+      true,
+    );
+  }
+
   loadDismissedNotifications();
+  updateSafeModeState(safeModeEnabled);
   renderNotificationList(currentNotifications);
   setupNotificationToggle();
+  setupSettingsToggle();
+  setupSafeModeToggle();
+  setupSafeConfirmations();
   refreshNotifications();
   setInterval(refreshNotifications, 60000);
 })();

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -1,12 +1,19 @@
 <style>
-  .notif-area {
+  .header-actions {
     position: relative;
     margin-left: auto;
     display: flex;
     align-items: center;
     gap: 10px;
   }
-  .notif-toggle {
+  .notif-area,
+  .settings-area {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+  .notif-toggle,
+  .settings-toggle {
     position: relative;
     background: rgba(255,255,255,0.05);
     border: 1px solid var(--border);
@@ -19,36 +26,17 @@
     cursor: pointer;
     box-shadow: var(--shadow);
   }
-  .notif-toggle:hover { border-color: rgba(49,196,255,0.5); }
-  .notif-icon {
+  .notif-toggle:hover,
+  .settings-toggle:hover { border-color: rgba(49,196,255,0.5); }
+  .notif-icon,
+  .settings-icon {
     width: 16px;
     height: 16px;
-    position: relative;
-    display: inline-block;
-  }
-  .notif-icon::before,
-  .notif-icon::after {
-    content: "";
-    position: absolute;
-    background: currentColor;
-    left: 50%;
-    transform: translateX(-50%);
-  }
-  .notif-icon::before {
-    width: 16px;
-    height: 14px;
-    border-radius: 8px 8px 4px 4px;
-    border: 2px solid currentColor;
-    border-bottom-width: 4px;
-    background: transparent;
-    box-sizing: border-box;
-    top: 0;
-  }
-  .notif-icon::after {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    bottom: -6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    line-height: 1;
   }
   .notif-badge {
     min-width: 20px;
@@ -122,4 +110,61 @@
     border: 1px solid rgba(255,99,71,0.35);
   }
   .notif-empty { padding: 14px; color: var(--muted); text-align: center; }
+
+  .settings-panel {
+    position: absolute;
+    right: 0;
+    top: 44px;
+    width: min(360px, 90vw);
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    box-shadow: var(--shadow);
+    display: none;
+    flex-direction: column;
+    overflow: hidden;
+    z-index: 20;
+  }
+  .settings-panel.open { display: flex; }
+  .settings-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border);
+    font-weight: 700;
+  }
+  .settings-body { padding: 10px 14px; display: flex; flex-direction: column; gap: 10px; }
+  .settings-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .settings-row strong { color: var(--text); }
+  .settings-safe { border-top: 1px solid var(--border); padding-top: 8px; }
+  .settings-hint { margin: 4px 0 0; color: var(--muted); font-size: 0.85rem; }
+  .switch { position: relative; width: 46px; height: 26px; }
+  .switch input { opacity: 0; width: 0; height: 0; }
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background: rgba(255,255,255,0.12);
+    border-radius: 999px;
+    transition: background 0.2s ease;
+    border: 1px solid var(--border);
+  }
+  .slider::before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 4px;
+    bottom: 3px;
+    background-color: white;
+    border-radius: 50%;
+    transition: transform 0.2s ease;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.25);
+  }
+  .switch input:checked + .slider {
+    background: linear-gradient(135deg, #1b87f1, #31c4ff);
+    border-color: rgba(49,196,255,0.55);
+  }
+  .switch input:checked + .slider::before { transform: translateX(18px); }
 </style>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -79,7 +79,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body>
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Aggiornamenti</span></h1>
@@ -187,7 +187,7 @@
                   </td>
                   <td data-label="Azioni">
                     <div class="actions">
-                      <form class="full-update-form" data-container-name="{{ c.name }}" method="post" action="{{ url_for('container_full_update', container_id=c.id) }}">
+                      <form class="full-update-form" data-container-name="{{ c.name }}" method="post" action="{{ url_for('container_full_update', container_id=c.id) }}" data-safe-confirm="Aggiornare l'immagine di {{ c.name }}?">
                         <button class="btn btn-full-update" type="submit">Aggiorna immagine</button>
                       </form>
                       <div class="small">ID: <code>{{ c.id }}</code></div>


### PR DESCRIPTION
## Summary
- add a header settings dropdown with system info and safe mode toggle alongside the bell notifications menu
- persist safe mode server-side and enforce confirmations or locks on destructive actions across containers, images, updates, and autodiscovery
- surface host OS, Docker version, and uptime in the header actions bar

## Testing
- python -m compileall d2ha

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921004a6ca0832d898772ac3b319be4)