### PR TITLE
Improve safe mode confirmation UX

### DIFF
--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -1,34 +1,97 @@
 <script>
 (() => {
-  const initialNotifications = {{ notifications|default({})|tojson }} || {};
-  const notifListEl = document.getElementById('notifList');
-  const notifBadgeEl = document.getElementById('notifBadge');
-  const notifPanelEl = document.getElementById('notifPanel');
-  const notifToggleEl = document.getElementById('notifToggle');
-  const settingsPanelEl = document.getElementById('settingsPanel');
-  const settingsToggleEl = document.getElementById('settingsToggle');
-  const safeModeToggleEl = document.getElementById('safeModeToggle');
-  let safeModeEnabled = (document.body.dataset.safeMode || '0') === '1';
-  let currentNotifications = initialNotifications;
-  let dismissedNotifications = {};
+    const initialNotifications = {{ notifications|default({})|tojson }} || {};
+    const notifListEl = document.getElementById('notifList');
+    const notifBadgeEl = document.getElementById('notifBadge');
+    const notifPanelEl = document.getElementById('notifPanel');
+    const notifToggleEl = document.getElementById('notifToggle');
+    const settingsPanelEl = document.getElementById('settingsPanel');
+    const settingsToggleEl = document.getElementById('settingsToggle');
+    const safeModeToggleEl = document.getElementById('safeModeToggle');
+    const safeConfirmState = {
+      modal: null,
+      message: null,
+      confirmBtn: null,
+      cancelBtn: null,
+      pendingForm: null,
+    };
+    let safeModeEnabled = (document.body.dataset.safeMode || '0') === '1';
+    let currentNotifications = initialNotifications;
+    let dismissedNotifications = {};
 
-  function updateSafeModeState(enabled) {
-    safeModeEnabled = !!enabled;
-    document.body.dataset.safeMode = safeModeEnabled ? '1' : '0';
-    if (safeModeToggleEl) {
-      safeModeToggleEl.checked = safeModeEnabled;
+    function updateSafeModeState(enabled) {
+      safeModeEnabled = !!enabled;
+      document.body.dataset.safeMode = safeModeEnabled ? '1' : '0';
+      if (safeModeToggleEl) {
+        safeModeToggleEl.checked = safeModeEnabled;
+      }
+      window.d2haSafeMode = { enabled: safeModeEnabled };
+      document.dispatchEvent(new CustomEvent('safe-mode-changed', { detail: { enabled: safeModeEnabled } }));
     }
-    window.d2haSafeMode = { enabled: safeModeEnabled };
-    document.dispatchEvent(new CustomEvent('safe-mode-changed', { detail: { enabled: safeModeEnabled } }));
-  }
 
-  function loadDismissedNotifications() {
-    try {
-      dismissedNotifications = JSON.parse(localStorage.getItem('d2haDismissedNotifications') || '{}') || {};
-    } catch (err) {
-      dismissedNotifications = {};
+    function loadDismissedNotifications() {
+      try {
+        dismissedNotifications = JSON.parse(localStorage.getItem('d2haDismissedNotifications') || '{}') || {};
+      } catch (err) {
+        dismissedNotifications = {};
+      }
     }
-  }
+
+    function ensureSafeConfirmModal() {
+      if (safeConfirmState.modal) return;
+
+      const backdrop = document.createElement('div');
+      backdrop.className = 'safe-confirm-backdrop';
+      backdrop.innerHTML = `
+        <div class="safe-confirm-modal" role="dialog" aria-modal="true" aria-labelledby="safe-confirm-title">
+          <h3 class="safe-confirm-title" id="safe-confirm-title">Conferma richiesta</h3>
+          <p class="safe-confirm-message" data-safe-confirm-message></p>
+          <div class="safe-confirm-actions">
+            <button type="button" class="btn btn-secondary" data-safe-cancel>Annulla</button>
+            <button type="button" class="btn" data-safe-confirm>Procedi</button>
+          </div>
+        </div>
+      `;
+
+      backdrop.addEventListener('click', (evt) => {
+        if (evt.target === backdrop) closeSafeConfirmModal();
+      });
+
+      const message = backdrop.querySelector('[data-safe-confirm-message]');
+      const confirmBtn = backdrop.querySelector('[data-safe-confirm]');
+      const cancelBtn = backdrop.querySelector('[data-safe-cancel]');
+
+      confirmBtn?.addEventListener('click', () => {
+        if (safeConfirmState.pendingForm) {
+          safeConfirmState.pendingForm.submit();
+        }
+        closeSafeConfirmModal();
+      });
+
+      cancelBtn?.addEventListener('click', () => closeSafeConfirmModal());
+
+      safeConfirmState.modal = backdrop;
+      safeConfirmState.message = message;
+      safeConfirmState.confirmBtn = confirmBtn;
+      safeConfirmState.cancelBtn = cancelBtn;
+
+      document.body.appendChild(backdrop);
+    }
+
+    function openSafeConfirmModal(message, form) {
+      ensureSafeConfirmModal();
+      safeConfirmState.pendingForm = form;
+      if (safeConfirmState.message) {
+        safeConfirmState.message.textContent = message;
+      }
+      safeConfirmState.modal?.classList.add('visible');
+      safeConfirmState.confirmBtn?.focus({ preventScroll: true });
+    }
+
+    function closeSafeConfirmModal() {
+      safeConfirmState.pendingForm = null;
+      safeConfirmState.modal?.classList.remove('visible');
+    }
 
   function saveDismissedNotifications() {
     localStorage.setItem('d2haDismissedNotifications', JSON.stringify(dismissedNotifications));
@@ -244,28 +307,29 @@
     }
   }
 
-  function setupSafeModeToggle() {
-    if (!safeModeToggleEl) return;
-    safeModeToggleEl.addEventListener('change', () => {
-      persistSafeMode(safeModeToggleEl.checked);
-    });
-  }
+    function setupSafeModeToggle() {
+      if (!safeModeToggleEl) return;
+      safeModeToggleEl.addEventListener('change', () => {
+        persistSafeMode(safeModeToggleEl.checked);
+      });
+    }
 
-  function setupSafeConfirmations() {
-    document.addEventListener(
-      'submit',
-      (ev) => {
-        const form = ev.target;
-        if (!(form instanceof HTMLFormElement)) return;
-        const message = form.dataset.safeConfirm;
-        if (!message || !safeModeEnabled) return;
-        if (!window.confirm(message)) {
+    function setupSafeConfirmations() {
+      document.addEventListener(
+        'submit',
+        (ev) => {
+          const form = ev.target;
+          if (!(form instanceof HTMLFormElement)) return;
+          const message = form.dataset.safeConfirm;
+          const handledElsewhere = form.dataset.safeModal === 'external';
+          if (!message || !safeModeEnabled || handledElsewhere) return;
+
           ev.preventDefault();
-        }
-      },
-      true,
-    );
-  }
+          openSafeConfirmModal(message, form);
+        },
+        true,
+      );
+    }
 
   loadDismissedNotifications();
   updateSafeModeState(safeModeEnabled);

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -151,9 +151,6 @@
   }
   .slider {
     position: absolute;
-  .switch input { opacity: 0; width: 0; height: 0; }
-  .slider {
-    position: absolute;
     cursor: pointer;
     inset: 0;
     background: rgba(255,255,255,0.12);
@@ -179,4 +176,55 @@
     border-color: rgba(49,196,255,0.55);
   }
   .switch input:checked + .slider::before { transform: translateX(18px); }
+
+  .safe-confirm-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(6, 8, 12, 0.75);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+    backdrop-filter: blur(2px);
+  }
+
+  .safe-confirm-backdrop.visible { display: flex; }
+
+  .safe-confirm-modal {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    box-shadow: var(--shadow);
+    padding: 18px 20px;
+    width: min(440px, 92vw);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .safe-confirm-title {
+    margin: 0;
+    font-size: 1.05rem;
+    letter-spacing: 0.01em;
+  }
+
+  .safe-confirm-message {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.5;
+  }
+
+  .safe-confirm-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+  }
+
+  .btn-secondary {
+    background: rgba(255,255,255,0.06);
+    border: 1px solid var(--border);
+    color: var(--text);
+  }
+
+  .btn-secondary:hover { border-color: rgba(49,196,255,0.45); }
 </style>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -187,7 +187,7 @@
                   </td>
                   <td data-label="Azioni">
                     <div class="actions">
-                      <form class="full-update-form" data-container-name="{{ c.name }}" method="post" action="{{ url_for('container_full_update', container_id=c.id) }}" data-safe-confirm="Aggiornare l'immagine di {{ c.name }}?">
+                      <form class="full-update-form" data-container-name="{{ c.name }}" method="post" action="{{ url_for('container_full_update', container_id=c.id) }}" data-safe-confirm="Aggiornare l'immagine di {{ c.name }}?" data-safe-modal="external">
                         <button class="btn btn-full-update" type="submit">Aggiorna immagine</button>
                       </form>
                       <div class="small">ID: <code>{{ c.id }}</code></div>


### PR DESCRIPTION
## Summary
- Fix the safe mode toggle styling so it remains visible in the settings dropdown.
- Replace the native confirmation with a themed safe-mode modal that matches the web UI.
- Prevent duplicate confirmations for image updates by skipping the global safe-mode prompt where a custom modal is already shown.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692107aa7238832d88da9d239b194381)