### PR TITLE
Enable safe mode by default and add container log shortcuts

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -50,7 +50,7 @@ mqtt_manager.start_periodic_publisher()
 
 
 _notifications_cache = {"ts": 0.0, "data": {}}
-_safe_mode_state = {"enabled": False}
+_safe_mode_state = {"enabled": True}
 _safe_mode_file = os.path.join(os.path.dirname(__file__), "safe_mode_state.json")
 
 
@@ -59,11 +59,11 @@ def _load_safe_mode_state():
     try:
         with open(_safe_mode_file, "r", encoding="utf-8") as fp:
             data = json.load(fp)
-            _safe_mode_state["enabled"] = bool(data.get("enabled", False))
+            _safe_mode_state["enabled"] = bool(data.get("enabled", True))
     except FileNotFoundError:
-        _safe_mode_state["enabled"] = False
+        _safe_mode_state["enabled"] = True
     except Exception:
-        _safe_mode_state["enabled"] = False
+        _safe_mode_state["enabled"] = True
 
 
 def _save_safe_mode_state():

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -109,7 +109,7 @@
               <span>{{ 'Senza stack' if stack == '_no_stack' else stack }}</span>
             </div>
             <div class="stack-actions">
-              <button type="button" class="btn-secondary deselect-stack">Deseleziona</button>
+              <button type="button" class="btn-secondary deselect-stack">Seleziona/Deseleziona tutti</button>
               <div class="stack-chip">{{ containers|length }} container</div>
             </div>
           </div>
@@ -192,12 +192,16 @@
     });
 
     deselectButtons.forEach((button) => {
-      button.addEventListener('click', () => {
+      button.addEventListener('click', (event) => {
+        event.stopPropagation();
         const stackSection = button.closest('.stack');
         if (!stackSection) return;
 
-        stackSection.querySelectorAll('input[type="checkbox"]').forEach((checkbox) => {
-          checkbox.checked = false;
+        const checkboxes = Array.from(stackSection.querySelectorAll('input[type="checkbox"]'));
+        const shouldSelectAll = checkboxes.some((checkbox) => !checkbox.checked);
+
+        checkboxes.forEach((checkbox) => {
+          checkbox.checked = shouldSelectAll;
         });
       });
     });

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -791,6 +791,15 @@
         });
       }
     });
+
+    const params = new URLSearchParams(window.location.search);
+    const initialContainerId = params.get('container');
+    const initialTab = params.get('tab') || 'info';
+    if (initialContainerId) {
+      const targetRow = document.querySelector(`[data-container-id="${initialContainerId}"]`);
+      const targetName = targetRow?.dataset?.containerName || 'Container';
+      openModal(initialContainerId, targetName, initialTab);
+    }
   </script>
 </body>
 </html>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -142,6 +142,25 @@
       font-size: 0.9rem;
     }
     .container-list small { color: var(--muted); display: block; margin-top: 2px; }
+    .container-actions { display: flex; align-items: center; gap: 8px; }
+    .log-link {
+      width: 26px;
+      height: 26px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      background: rgba(255,255,255,0.04);
+      color: var(--muted);
+      transition: all 0.15s ease;
+    }
+    .log-link:hover {
+      color: var(--accent);
+      border-color: rgba(49,196,255,0.4);
+      background: rgba(49,196,255,0.08);
+    }
+    .log-link svg { width: 16px; height: 16px; fill: currentColor; }
     .pill {
       padding: 4px 10px;
       border-radius: 999px;
@@ -319,7 +338,19 @@
                   <small>{{ c.image }}</small>
                 </div>
                 {% set status = c.status.lower() %}
-                <span class="status-indicator {% if status == 'running' %}status-running{% elif status == 'paused' %}status-paused{% else %}status-stopped{% endif %}" title="{{ c.status }}" aria-label="{{ c.status }}"></span>
+                <div class="container-actions">
+                  <a
+                    class="log-link"
+                    href="{{ url_for('containers_view') }}?container={{ c.id }}&tab=logs"
+                    title="Apri log di {{ c.name }}"
+                    aria-label="Apri log di {{ c.name }}"
+                  >
+                    <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                      <path d="M7 4a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h10a2 2 0 0 0 2-2V8.5L13.5 4H7zm6 5V5.5L17.5 9H13z"/>
+                    </svg>
+                  </a>
+                  <span class="status-indicator {% if status == 'running' %}status-running{% elif status == 'paused' %}status-paused{% else %}status-stopped{% endif %}" title="{{ c.status }}" aria-label="{{ c.status }}"></span>
+                </div>
               </li>
             {% endfor %}
           </ul>


### PR DESCRIPTION
## Summary
- default safe mode to enabled and persist fallback when state file is missing
- add direct log shortcuts from the Home sidebar and auto-open container logs via URL parameters
- improve autodiscovery bulk toggle button behavior and labeling

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210ad3f144832dba7f675c4f3849f7)