### PR TITLE
Add header clock and improve container log interactions

### DIFF
--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -28,9 +28,11 @@
     .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 16px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
-    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:8px; flex-wrap:wrap; margin-bottom:10px; }
+    .stack-card { display:flex; flex-direction:column; gap:14px; }
+    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; margin-bottom:4px; }
     .stack-toggle { margin-bottom:0; cursor:pointer; }
-    .stack-title { font-size:1rem; font-weight:700; display:flex; align-items:center; gap:8px; }
+    .stack-title { font-size:1rem; font-weight:800; display:flex; align-items:center; gap:10px; letter-spacing:0.02em; }
+    .stack-name { text-transform: uppercase; letter-spacing:0.08em; }
     .stack-chip { padding:4px 10px; border-radius:999px; background: rgba(255,255,255,0.05); color: var(--muted); font-size:0.8rem; }
     .stack-toggle-btn { border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); border-radius:8px; padding:4px 8px; cursor:pointer; display:inline-flex; align-items:center; gap:6px; }
     .stack-toggle-btn:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
@@ -72,7 +74,6 @@
     .modal-backdrop { position: fixed; inset:0; background: rgba(0,0,0,0.65); display:none; align-items:center; justify-content:center; z-index: 50; padding:20px; }
     .modal-backdrop.visible { display:flex; }
     .modal { background: var(--panel-2); border:1px solid var(--border); border-radius:16px; width:min(1100px, 100%); height:82vh; max-height:82vh; overflow:hidden; box-shadow: var(--shadow); display:flex; flex-direction:column; }
-    .log-only-modal { width:min(960px, 100%); height:70vh; max-height:70vh; }
     .modal-header { display:flex; align-items:center; justify-content:space-between; padding:16px 18px; border-bottom:1px solid var(--border); background: linear-gradient(90deg, #171d2b, #111524); }
     .modal-title { font-weight:800; font-size:1rem; letter-spacing:0.02em; }
     .modal-close { background:none; border:none; color:var(--muted); font-size:1.2rem; cursor:pointer; }
@@ -101,9 +102,6 @@
     .logs-area .log-error { border-color:#ff8a7a; background:rgba(255,138,122,0.08); }
     .logs-area .log-debug { border-color:#9aa7bd; background:rgba(154,167,189,0.06); color:#c5cee0; }
     .logs-area .log-other { border-color:rgba(255,255,255,0.08); }
-    .inline-controls { display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:8px; }
-    .inline-controls .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.05); color: var(--text); cursor:pointer; transition: all 0.15s ease; }
-    .inline-controls .inline-btn:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
     .controls { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
     .select, .input { background: #0f141f; color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
     .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background:#1d2535; color: var(--text); cursor:pointer; }
@@ -157,13 +155,13 @@
     </div>
 
     {% for stack in stacks %}
-      <section class="card">
+      <section class="card stack-card">
         <div class="stack-header stack-toggle" data-stack-toggle>
           <div class="stack-title">
             <button class="stack-toggle-btn" type="button" aria-expanded="true" aria-label="Mostra o nascondi sezione">
               <span class="chevron">▾</span>
             </button>
-            <span>{{ 'Senza stack' if stack.name == '_no_stack' else stack.name }}</span>
+            <span class="stack-name">{{ 'Senza stack' if stack.name == '_no_stack' else stack.name }}</span>
           </div>
           <div class="stack-chip">{{ stack.containers|length }} container</div>
         </div>
@@ -244,7 +242,7 @@
                   <td data-label="Azioni">
                     <div class="actions">
                       <button class="btn btn-strong" type="button" data-open-modal data-container-id="{{ c.id }}" data-container-name="{{ c.name }}">Dettagli</button>
-                      <button class="btn btn-ghost" type="button" data-open-inline-logs data-container-id="{{ c.id }}" data-container-name="{{ c.name }}">Logs</button>
+                      <button class="btn btn-ghost" type="button" data-open-modal data-tab="logs" data-container-id="{{ c.id }}" data-container-name="{{ c.name }}">Logs</button>
                     </div>
                   </td>
                 </tr>
@@ -402,31 +400,6 @@
       </div>
     </div>
   </div>
-  <div class="modal-backdrop" id="logs-inline-modal" aria-hidden="true">
-    <div class="modal log-only-modal">
-      <div class="modal-header">
-        <div class="modal-title" id="logs-inline-title">Log container</div>
-        <button class="modal-close" id="logs-inline-close" aria-label="Chiudi log">✕</button>
-      </div>
-      <div class="modal-body">
-        <div class="inline-controls">
-          <label class="muted"><input type="checkbox" id="logs-inline-auto" checked> Auto-refresh</label>
-          <label class="muted">Linee
-            <select id="logs-inline-tail" class="select">
-              <option value="10">10</option>
-              <option value="50">50</option>
-              <option value="100" selected>100</option>
-              <option value="150">150</option>
-              <option value="500">500</option>
-              <option value="all">Senza limiti</option>
-            </select>
-          </label>
-          <button class="inline-btn" id="logs-inline-refresh">Aggiorna ora</button>
-        </div>
-        <pre class="logs-area" id="logs-inline-output">Seleziona un container...</pre>
-      </div>
-    </div>
-  </div>
   <div class="toast-container" id="toast-container"></div>
   {% include 'partials/notifications_script.html' %}
   <script>
@@ -479,22 +452,13 @@
     const bulkCount = document.getElementById('bulk-count');
     const bulkButtons = Array.from(document.querySelectorAll('[data-bulk-action]'));
     const selectionInputs = Array.from(document.querySelectorAll('.container-select'));
-    const inlineLogModal = document.getElementById('logs-inline-modal');
-    const inlineLogTitle = document.getElementById('logs-inline-title');
-    const inlineLogOutput = document.getElementById('logs-inline-output');
-    const inlineLogAuto = document.getElementById('logs-inline-auto');
-    const inlineLogTail = document.getElementById('logs-inline-tail');
-    const inlineLogRefresh = document.getElementById('logs-inline-refresh');
-    const inlineLogClose = document.getElementById('logs-inline-close');
 
     let currentContainerId = null;
     let statsInterval = null;
     let logsInterval = null;
-    let inlineLogsInterval = null;
     let statsHistory = { cpu: [], ram: [], net: [] };
     let lastNet = null;
     const selectedContainers = new Map();
-    let inlineLogContainerId = null;
 
     const showToast = (message, { type = 'info', actions = [] } = {}) => {
       const toast = document.createElement('div');
@@ -750,18 +714,6 @@
       }
     };
 
-    const updateInlineLogs = async () => {
-      if (!inlineLogContainerId) return;
-      inlineLogOutput.textContent = 'Caricamento log...';
-      try {
-        const tail = inlineLogTail.value;
-        const data = await fetchJSON(`/api/containers/${inlineLogContainerId}/logs?tail=${tail}`);
-        renderLogs(data.logs, inlineLogOutput);
-      } catch (err) {
-        inlineLogOutput.textContent = 'Impossibile recuperare i log';
-      }
-    };
-
     const updateUpdates = async (force = false) => {
       if (!currentContainerId) return;
       try {
@@ -808,30 +760,6 @@
       clearInterval(logsInterval);
     };
 
-    const stopInlineLogs = () => {
-      clearInterval(inlineLogsInterval);
-      inlineLogsInterval = null;
-    };
-
-    const openInlineLogModal = (id, name) => {
-      stopInlineLogs();
-      inlineLogContainerId = id;
-      inlineLogTitle.textContent = `Log · ${name}`;
-      inlineLogModal.classList.add('visible');
-      inlineLogModal.setAttribute('aria-hidden', 'false');
-      updateInlineLogs();
-      if (inlineLogAuto.checked) {
-        inlineLogsInterval = setInterval(updateInlineLogs, 4000);
-      }
-    };
-
-    const closeInlineLogModal = () => {
-      stopInlineLogs();
-      inlineLogContainerId = null;
-      inlineLogModal.classList.remove('visible');
-      inlineLogModal.setAttribute('aria-hidden', 'true');
-    };
-
     const openModal = (id, name, initialTab = 'info') => {
       currentContainerId = id;
       modalTitle.textContent = name;
@@ -859,11 +787,6 @@
       if (e.target === modalEl) closeModal();
     });
 
-    inlineLogClose.addEventListener('click', closeInlineLogModal);
-    inlineLogModal.addEventListener('click', (e) => {
-      if (e.target === inlineLogModal) closeInlineLogModal();
-    });
-
     tabButtons.forEach(btn => {
       btn.addEventListener('click', () => setPanel(btn.dataset.tab));
     });
@@ -871,14 +794,8 @@
     document.querySelectorAll('[data-open-modal]').forEach(btn => {
       btn.addEventListener('click', (e) => {
         e.stopPropagation();
-        openModal(btn.dataset.containerId, btn.dataset.containerName);
-      });
-    });
-
-    document.querySelectorAll('[data-open-inline-logs]').forEach(btn => {
-      btn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        openInlineLogModal(btn.dataset.containerId, btn.dataset.containerName);
+        const targetTab = btn.dataset.tab || 'info';
+        openModal(btn.dataset.containerId, btn.dataset.containerName, targetTab);
       });
     });
 
@@ -899,21 +816,6 @@
       } else {
         clearInterval(logsInterval);
       }
-    });
-
-    inlineLogRefresh.addEventListener('click', () => {
-      updateInlineLogs();
-    });
-
-    inlineLogAuto.addEventListener('change', () => {
-      stopInlineLogs();
-      if (inlineLogAuto.checked && inlineLogContainerId) {
-        inlineLogsInterval = setInterval(updateInlineLogs, 4000);
-      }
-    });
-
-    inlineLogTail.addEventListener('change', () => {
-      updateInlineLogs();
     });
 
     updatesSave.addEventListener('click', async () => {

--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -1,4 +1,5 @@
 <div class="header-actions">
+  <div class="header-clock" id="header-clock" aria-label="Orologio"></div>
   <div class="notif-area">
     <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
       <span class="notif-icon" aria-hidden="true">🔔</span>

--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -7,6 +7,7 @@
     const notifToggleEl = document.getElementById('notifToggle');
     const settingsPanelEl = document.getElementById('settingsPanel');
     const settingsToggleEl = document.getElementById('settingsToggle');
+    const headerClockEl = document.getElementById('header-clock');
     const safeModeToggleEl = document.getElementById('safeModeToggle');
     const safeConfirmState = {
       modal: null,
@@ -18,6 +19,21 @@
     let safeModeEnabled = (document.body.dataset.safeMode || '0') === '1';
     let currentNotifications = initialNotifications;
     let dismissedNotifications = {};
+    let clockInterval = null;
+
+    function startClock() {
+      if (!headerClockEl) return;
+      clearInterval(clockInterval);
+
+      const updateClock = () => {
+        const now = new Date();
+        const pad = (v) => String(v).padStart(2, '0');
+        headerClockEl.textContent = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+      };
+
+      updateClock();
+      clockInterval = setInterval(updateClock, 1000);
+    }
 
     function updateSafeModeState(enabled) {
       safeModeEnabled = !!enabled;
@@ -92,6 +108,8 @@
       safeConfirmState.pendingForm = null;
       safeConfirmState.modal?.classList.remove('visible');
     }
+
+    startClock();
 
   function saveDismissedNotifications() {
     localStorage.setItem('d2haDismissedNotifications', JSON.stringify(dismissedNotifications));

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -6,6 +6,18 @@
     align-items: center;
     gap: 10px;
   }
+  .header-clock {
+    font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    padding: 10px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: rgba(255,255,255,0.04);
+    color: var(--text);
+    letter-spacing: 0.08em;
+    box-shadow: var(--shadow);
+    min-width: 110px;
+    text-align: center;
+  }
   .notif-area,
   .settings-area {
     position: relative;


### PR DESCRIPTION
## Summary
- add a digital clock next to the notification panel in the header
- improve container stack spacing and uppercase stack names
- open the Logs button in the details modal on the Logs tab

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921120cef08832db2a898054d78de63)