### PR TITLE
Add severity filters to log views

### DIFF
--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -349,18 +349,28 @@
         <div class="tab-panel logs-panel" data-panel="logs">
           <div class="controls">
             <label class="muted"><input type="checkbox" id="logs-auto" checked> Auto-refresh</label>
-            <label class="muted">Linee
-              <select id="logs-tail" class="select">
-                <option value="10">10</option>
-                <option value="50">50</option>
-                <option value="100" selected>100</option>
-                <option value="150">150</option>
-                <option value="500">500</option>
-                <option value="all">Senza limiti</option>
-              </select>
-            </label>
-            <button class="inline-btn" id="logs-refresh">Aggiorna ora</button>
-          </div>
+          <label class="muted">Linee
+            <select id="logs-tail" class="select">
+              <option value="10">10</option>
+              <option value="50">50</option>
+              <option value="100" selected>100</option>
+              <option value="150">150</option>
+              <option value="500">500</option>
+              <option value="all">Senza limiti</option>
+            </select>
+          </label>
+          <label class="muted">Severità
+            <select id="logs-severity" class="select">
+              <option value="all" selected>Tutte</option>
+              <option value="error">Errori</option>
+              <option value="warn">Warning</option>
+              <option value="info">Info</option>
+              <option value="debug">Debug</option>
+              <option value="other">Altro</option>
+            </select>
+          </label>
+          <button class="inline-btn" id="logs-refresh">Aggiorna ora</button>
+        </div>
           <pre class="logs-area" id="logs-output">Seleziona un container...</pre>
         </div>
 
@@ -442,6 +452,7 @@
     const logOutput = document.getElementById('logs-output');
     const logAuto = document.getElementById('logs-auto');
     const logTail = document.getElementById('logs-tail');
+    const logSeverity = document.getElementById('logs-severity');
     const logRefreshBtn = document.getElementById('logs-refresh');
     const updatesFrequency = document.getElementById('updates-frequency');
     const updatesSave = document.getElementById('updates-save');
@@ -456,6 +467,7 @@
     let currentContainerId = null;
     let statsInterval = null;
     let logsInterval = null;
+    let lastLogs = '';
     let statsHistory = { cpu: [], ram: [], net: [] };
     let lastNet = null;
     const selectedContainers = new Map();
@@ -685,6 +697,19 @@
       return 'log-other';
     };
 
+    const matchesSeverity = (line, filter) => {
+      if (filter === 'all') return true;
+      const levelMap = {
+        'log-error': 'error',
+        'log-warn': 'warn',
+        'log-info': 'info',
+        'log-debug': 'debug',
+        'log-other': 'other',
+      };
+      const levelClass = getLogLevel(line);
+      return levelMap[levelClass] === filter;
+    };
+
     const renderLogs = (logs, target = logOutput) => {
       if (!logs) {
         target.textContent = 'Nessun log disponibile';
@@ -692,15 +717,17 @@
       }
 
       const lines = logs.split(/\r?\n/);
-      const html = lines
+      const filteredLines = lines
         .filter((line) => line !== '')
+        .filter((line) => matchesSeverity(line, logSeverity.value));
+      const html = filteredLines
         .map((line) => {
           const levelClass = getLogLevel(line);
           return `<div class="log-line ${levelClass}"><span class="log-bullet">•</span><span>${escapeHtml(line)}</span></div>`;
         })
         .join('');
 
-      target.innerHTML = html || '<div class="muted">Nessun log disponibile</div>';
+      target.innerHTML = html || '<div class="muted">Nessun log per la severità selezionata</div>';
     };
 
     const updateLogs = async () => {
@@ -708,7 +735,8 @@
       try {
         const tail = logTail.value;
         const data = await fetchJSON(`/api/containers/${currentContainerId}/logs?tail=${tail}`);
-        renderLogs(data.logs);
+        lastLogs = data.logs;
+        renderLogs(lastLogs);
       } catch (err) {
         logOutput.textContent = 'Impossibile recuperare i log';
       }
@@ -780,6 +808,7 @@
       modalEl.classList.remove('visible');
       modalEl.setAttribute('aria-hidden', 'true');
       currentContainerId = null;
+      lastLogs = '';
     };
 
     document.getElementById('modal-close').addEventListener('click', closeModal);
@@ -809,6 +838,8 @@
     logRefreshBtn.addEventListener('click', () => {
       updateLogs();
     });
+
+    logSeverity.addEventListener('change', () => renderLogs(lastLogs));
 
     logAuto.addEventListener('change', () => {
       if (logAuto.checked) {

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -492,6 +492,16 @@
               <option value="all">Senza limiti</option>
             </select>
           </label>
+          <label class="muted">Severità
+            <select id="home-log-severity" class="select">
+              <option value="all" selected>Tutte</option>
+              <option value="error">Errori</option>
+              <option value="warn">Warning</option>
+              <option value="info">Info</option>
+              <option value="debug">Debug</option>
+              <option value="other">Altro</option>
+            </select>
+          </label>
           <button class="inline-btn" id="home-log-refresh">Aggiorna ora</button>
         </div>
         <pre class="logs-area" id="home-log-output">Seleziona un container...</pre>
@@ -510,10 +520,12 @@
     const homeLogOutput = document.getElementById('home-log-output');
     const homeLogAuto = document.getElementById('home-log-auto');
     const homeLogTail = document.getElementById('home-log-tail');
+    const homeLogSeverity = document.getElementById('home-log-severity');
     const homeLogRefresh = document.getElementById('home-log-refresh');
     const homeLogTriggers = Array.from(document.querySelectorAll('[data-open-home-logs]'));
     let homeLogContainerId = null;
     let homeLogInterval = null;
+    let homeLogBuffer = '';
 
     const escapeLogHtml = (str) =>
       (str || '')
@@ -532,6 +544,19 @@
       return 'log-other';
     };
 
+    const matchesHomeSeverity = (line, filter) => {
+      if (filter === 'all') return true;
+      const levelMap = {
+        'log-error': 'error',
+        'log-warn': 'warn',
+        'log-info': 'info',
+        'log-debug': 'debug',
+        'log-other': 'other',
+      };
+      const levelClass = getLogLevel(line);
+      return levelMap[levelClass] === filter;
+    };
+
     const renderHomeLogs = (logs) => {
       if (!logs) {
         homeLogOutput.textContent = 'Nessun log disponibile';
@@ -539,15 +564,17 @@
       }
 
       const lines = logs.split(/\r?\n/);
-      const html = lines
+      const filteredLines = lines
         .filter((line) => line !== '')
+        .filter((line) => matchesHomeSeverity(line, homeLogSeverity.value));
+      const html = filteredLines
         .map((line) => {
           const levelClass = getLogLevel(line);
           return `<div class="log-line ${levelClass}"><span class="log-bullet">•</span><span>${escapeLogHtml(line)}</span></div>`;
         })
         .join('');
 
-      homeLogOutput.innerHTML = html || '<div class="muted">Nessun log disponibile</div>';
+      homeLogOutput.innerHTML = html || '<div class="muted">Nessun log per la severità selezionata</div>';
     };
 
     const updateHomeLogs = async () => {
@@ -558,7 +585,8 @@
         const res = await fetch(`/api/containers/${homeLogContainerId}/logs?tail=${tail}`);
         if (!res.ok) throw new Error('Request failed');
         const data = await res.json();
-        renderHomeLogs(data.logs);
+        homeLogBuffer = data.logs;
+        renderHomeLogs(homeLogBuffer);
       } catch (err) {
         homeLogOutput.textContent = 'Impossibile recuperare i log';
       }
@@ -584,6 +612,7 @@
       clearInterval(homeLogInterval);
       homeLogInterval = null;
       homeLogContainerId = null;
+      homeLogBuffer = '';
       homeLogModal.classList.remove('visible');
       homeLogModal.setAttribute('aria-hidden', 'true');
     };
@@ -597,6 +626,7 @@
     homeLogRefresh.addEventListener('click', updateHomeLogs);
     homeLogAuto.addEventListener('change', startHomeLogLoop);
     homeLogTail.addEventListener('change', updateHomeLogs);
+    homeLogSeverity.addEventListener('change', () => renderHomeLogs(homeLogBuffer));
     homeLogClose.addEventListener('click', closeHomeLogModal);
     homeLogModal.addEventListener('click', (e) => {
       if (e.target === homeLogModal) closeHomeLogModal();


### PR DESCRIPTION
## Summary
- add severity dropdowns to container and home log modals
- filter rendered log lines by selected severity while preserving previous fetches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692112e35024832d8e7c97ce2958ec59)