### PR TITLE
Add backend status indicator and modal

### DIFF
--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -1,4 +1,7 @@
 <div class="header-actions">
+  <div id="backend-status-indicator" class="backend-status backend-status-ok" title="Stato backend" aria-label="Stato backend">
+    <span class="backend-status-icon" aria-hidden="true">📡</span>
+  </div>
   <div class="header-clock" id="header-clock" aria-label="Orologio"></div>
   <div class="notif-area">
     <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
@@ -47,6 +50,17 @@
           </div>
         </div>
       </div>
+    </div>
+  </div>
+</div>
+
+<div id="backend-status-modal" class="backend-modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="backend-status-title">
+  <div class="backend-modal" role="document">
+    <h2 id="backend-status-title">Stato aggiornamento dati</h2>
+    <p id="backend-status-last-update" class="backend-modal-text">Nessun aggiornamento riuscito di recente</p>
+    <div class="backend-modal-actions">
+      <button type="button" id="backend-status-refresh-btn" class="backend-modal-btn primary">Aggiorna ora</button>
+      <button type="button" id="backend-status-close-btn" class="backend-modal-btn">Chiudi</button>
     </div>
   </div>
 </div>

--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -8,6 +8,11 @@
     const settingsPanelEl = document.getElementById('settingsPanel');
     const settingsToggleEl = document.getElementById('settingsToggle');
     const headerClockEl = document.getElementById('header-clock');
+    const backendStatusEl = document.getElementById('backend-status-indicator');
+    const backendStatusModalEl = document.getElementById('backend-status-modal');
+    const backendStatusLastUpdateEl = document.getElementById('backend-status-last-update');
+    const backendRefreshBtn = document.getElementById('backend-status-refresh-btn');
+    const backendCloseBtn = document.getElementById('backend-status-close-btn');
     const safeModeToggleEl = document.getElementById('safeModeToggle');
     const safeConfirmState = {
       modal: null,
@@ -20,6 +25,14 @@
     let currentNotifications = initialNotifications;
     let dismissedNotifications = {};
     let clockInterval = null;
+    let lastSuccessfulPing = null;
+    let consecutiveErrors = 0;
+    let backendPingTimer = null;
+
+    function formatClock(dateObj) {
+      const pad = (v) => String(v).padStart(2, '0');
+      return `${pad(dateObj.getHours())}:${pad(dateObj.getMinutes())}:${pad(dateObj.getSeconds())}`;
+    }
 
     function startClock() {
       if (!headerClockEl) return;
@@ -27,8 +40,7 @@
 
       const updateClock = () => {
         const now = new Date();
-        const pad = (v) => String(v).padStart(2, '0');
-        headerClockEl.textContent = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+        headerClockEl.textContent = formatClock(now);
       };
 
       updateClock();
@@ -43,6 +55,89 @@
       }
       window.d2haSafeMode = { enabled: safeModeEnabled };
       document.dispatchEvent(new CustomEvent('safe-mode-changed', { detail: { enabled: safeModeEnabled } }));
+    }
+
+    function updateBackendStatus(durationMs) {
+      const now = Date.now();
+      const age = lastSuccessfulPing ? now - lastSuccessfulPing : Infinity;
+      const el = backendStatusEl;
+      if (!el) return;
+
+      el.classList.remove('backend-status-ok', 'backend-status-degraded', 'backend-status-down');
+
+      if (consecutiveErrors >= 2 || age > 30000) {
+        el.classList.add('backend-status-down');
+      } else if (age > 20000 || (durationMs || 0) > 800) {
+        el.classList.add('backend-status-degraded');
+      } else {
+        el.classList.add('backend-status-ok');
+      }
+    }
+
+    function updateBackendModalText() {
+      if (!backendStatusLastUpdateEl) return;
+      if (lastSuccessfulPing) {
+        backendStatusLastUpdateEl.textContent = `Ultimo aggiornamento dati: ${formatClock(new Date(lastSuccessfulPing))}`;
+      } else {
+        backendStatusLastUpdateEl.textContent = 'Nessun aggiornamento riuscito di recente';
+      }
+    }
+
+    function closeBackendModal() {
+      backendStatusModalEl?.classList.remove('visible');
+    }
+
+    async function pingBackend() {
+      const start = performance.now();
+      let durationMs = 0;
+      try {
+        const res = await fetch('/api/overview', { cache: 'no-store' });
+        durationMs = performance.now() - start;
+        if (!res.ok) throw new Error(`Status ${res.status}`);
+        await res.json();
+        lastSuccessfulPing = Date.now();
+        consecutiveErrors = 0;
+        updateBackendStatus(durationMs);
+        updateBackendModalText();
+      } catch (err) {
+        console.error('Backend healthcheck failed', err);
+        consecutiveErrors += 1;
+        updateBackendStatus(durationMs);
+      }
+    }
+
+    function setupBackendStatusModal() {
+      if (backendStatusEl) {
+        backendStatusEl.addEventListener('click', () => {
+          updateBackendModalText();
+          backendStatusModalEl?.classList.add('visible');
+        });
+      }
+
+      backendCloseBtn?.addEventListener('click', closeBackendModal);
+
+      backendStatusModalEl?.addEventListener('click', (evt) => {
+        if (evt.target === backendStatusModalEl) {
+          closeBackendModal();
+        }
+      });
+
+      backendRefreshBtn?.addEventListener('click', async () => {
+        await pingBackend();
+        try {
+          if (typeof window.refreshOverview === 'function') {
+            window.refreshOverview();
+          }
+        } catch (err) {
+          console.error('Impossibile aggiornare immediatamente i dati', err);
+        }
+      });
+    }
+
+    function startBackendMonitor() {
+      pingBackend();
+      clearInterval(backendPingTimer);
+      backendPingTimer = setInterval(pingBackend, 5000);
     }
 
     function loadDismissedNotifications() {
@@ -356,6 +451,8 @@
   setupSettingsToggle();
   setupSafeModeToggle();
   setupSafeConfirmations();
+  setupBackendStatusModal();
+  startBackendMonitor();
   refreshNotifications();
   setInterval(refreshNotifications, 60000);
 })();

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -6,6 +6,28 @@
     align-items: center;
     gap: 10px;
   }
+  .backend-status {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 0.75rem;
+    cursor: pointer;
+    transition: color 0.2s ease, opacity 0.2s ease;
+    color: #4caf50;
+  }
+  .backend-status:hover { opacity: 0.9; }
+  .backend-status-ok { color: #4caf50; }
+  .backend-status-degraded { color: #ff9800; }
+  .backend-status-down { color: #f44336; }
+  .backend-status-icon {
+    width: 16px;
+    height: 16px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    line-height: 1;
+  }
   .header-clock {
     font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
     padding: 10px 12px;
@@ -64,6 +86,62 @@
     padding: 0 6px;
     box-shadow: 0 4px 12px rgba(255,99,71,0.35);
   }
+  .backend-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(6, 8, 12, 0.75);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 60;
+    padding: 20px;
+    backdrop-filter: blur(2px);
+  }
+  .backend-modal-backdrop.visible { display: flex; }
+  .backend-modal {
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    width: min(420px, 96vw);
+    box-shadow: var(--shadow);
+    padding: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .backend-modal h2 {
+    margin: 0;
+    font-size: 1.05rem;
+    letter-spacing: 0.02em;
+  }
+  .backend-modal-text {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.4;
+  }
+  .backend-modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+  .backend-modal-btn {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 8px 14px;
+    background: rgba(255,255,255,0.05);
+    color: var(--text);
+    cursor: pointer;
+    font-weight: 700;
+    transition: border-color 0.15s ease, background 0.15s ease, transform 0.05s ease;
+  }
+  .backend-modal-btn.primary {
+    background: linear-gradient(135deg, #1b87f1, #31c4ff);
+    color: #0c121e;
+    border-color: rgba(49,196,255,0.55);
+    box-shadow: 0 6px 18px rgba(49,196,255,0.35);
+  }
+  .backend-modal-btn:hover { transform: translateY(-1px); border-color: rgba(49,196,255,0.4); }
   .notif-panel {
     position: absolute;
     right: 0;


### PR DESCRIPTION
## Summary
- add backend status indicator and modal trigger near the header clock
- style backend health indicator and modal to match the existing dark theme
- implement periodic backend health checks with manual refresh support

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692119845a40832d8acd1a2dc199b5b9)