### PR TITLE
Add performance mode toggle and adjust polling behavior

### DIFF
--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -471,6 +471,12 @@
     let statsHistory = { cpu: [], ram: [], net: [] };
     let lastNet = null;
     const selectedContainers = new Map();
+    const pollingDefaults = { statsIntervalMs: 3000, logsIntervalMs: 4000, historyLimit: 40 };
+    const pollingPerformance = { statsIntervalMs: 5000, logsIntervalMs: 7000, historyLimit: 20 };
+    let statsIntervalMs = pollingDefaults.statsIntervalMs;
+    let logsIntervalMs = pollingDefaults.logsIntervalMs;
+    let statsSampleLimit = pollingDefaults.historyLimit;
+    let activeTab = 'info';
 
     const showToast = (message, { type = 'info', actions = [] } = {}) => {
       const toast = document.createElement('div');
@@ -583,6 +589,25 @@
       tabPanels.forEach(panel => panel.classList.toggle('active', panel.dataset.panel === name));
     };
 
+    const handleTabChange = (name) => {
+      setPanel(name);
+      activeTab = name;
+
+      if (window.d2haSettings?.performanceMode) {
+        stopPolling();
+        if (name === 'stats') {
+          updateStats();
+          statsInterval = setInterval(updateStats, statsIntervalMs);
+        }
+        if (name === 'logs') {
+          updateLogs();
+          if (logAuto.checked) {
+            logsInterval = setInterval(updateLogs, logsIntervalMs);
+          }
+        }
+      }
+    };
+
     const renderList = (target, items, formatter, emptyText = 'Nessun dato') => {
       if (!items || !items.length) {
         target.textContent = emptyText;
@@ -668,9 +693,9 @@
         statsHistory.cpu.push(data.cpu_percent);
         statsHistory.ram.push(data.mem_percent);
         statsHistory.net.push(netDelta.rx + netDelta.tx);
-        statsHistory.cpu = statsHistory.cpu.slice(-40);
-        statsHistory.ram = statsHistory.ram.slice(-40);
-        statsHistory.net = statsHistory.net.slice(-40);
+        statsHistory.cpu = statsHistory.cpu.slice(-statsSampleLimit);
+        statsHistory.ram = statsHistory.ram.slice(-statsSampleLimit);
+        statsHistory.net = statsHistory.net.slice(-statsSampleLimit);
 
         drawSpark(document.getElementById('chart-cpu'), statsHistory.cpu, '#31c4ff', 100);
         drawSpark(document.getElementById('chart-ram'), statsHistory.ram, '#8ef0c5', 100);
@@ -777,9 +802,9 @@
     const startPolling = () => {
       clearInterval(statsInterval);
       clearInterval(logsInterval);
-      statsInterval = setInterval(updateStats, 3000);
+      statsInterval = setInterval(updateStats, statsIntervalMs);
       if (logAuto.checked) {
-        logsInterval = setInterval(updateLogs, 4000);
+        logsInterval = setInterval(updateLogs, logsIntervalMs);
       }
     };
 
@@ -795,12 +820,26 @@
       lastNet = null;
       modalEl.classList.add('visible');
       modalEl.setAttribute('aria-hidden', 'false');
+      activeTab = initialTab;
       setPanel(initialTab);
       updateDetails();
-      updateStats();
-      updateLogs();
       updateUpdates();
-      startPolling();
+      if (window.d2haSettings?.performanceMode) {
+        if (initialTab === 'stats') {
+          updateStats();
+          statsInterval = setInterval(updateStats, statsIntervalMs);
+        }
+        if (initialTab === 'logs') {
+          updateLogs();
+          if (logAuto.checked) {
+            logsInterval = setInterval(updateLogs, logsIntervalMs);
+          }
+        }
+      } else {
+        updateStats();
+        updateLogs();
+        startPolling();
+      }
     };
 
     const closeModal = () => {
@@ -811,13 +850,43 @@
       lastLogs = '';
     };
 
+    window.registerPerformanceHandler?.((enabled) => {
+      statsIntervalMs = enabled ? pollingPerformance.statsIntervalMs : pollingDefaults.statsIntervalMs;
+      logsIntervalMs = enabled ? pollingPerformance.logsIntervalMs : pollingDefaults.logsIntervalMs;
+      statsSampleLimit = enabled ? pollingPerformance.historyLimit : pollingDefaults.historyLimit;
+      statsHistory.cpu = statsHistory.cpu.slice(-statsSampleLimit);
+      statsHistory.ram = statsHistory.ram.slice(-statsSampleLimit);
+      statsHistory.net = statsHistory.net.slice(-statsSampleLimit);
+
+      if (!modalEl.classList.contains('visible')) {
+        stopPolling();
+        return;
+      }
+
+      if (enabled) {
+        stopPolling();
+        if (activeTab === 'stats') {
+          updateStats();
+          statsInterval = setInterval(updateStats, statsIntervalMs);
+        }
+        if (activeTab === 'logs' && logAuto.checked) {
+          updateLogs();
+          logsInterval = setInterval(updateLogs, logsIntervalMs);
+        }
+      } else {
+        updateStats();
+        updateLogs();
+        startPolling();
+      }
+    });
+
     document.getElementById('modal-close').addEventListener('click', closeModal);
     modalEl.addEventListener('click', (e) => {
       if (e.target === modalEl) closeModal();
     });
 
     tabButtons.forEach(btn => {
-      btn.addEventListener('click', () => setPanel(btn.dataset.tab));
+      btn.addEventListener('click', () => handleTabChange(btn.dataset.tab));
     });
 
     document.querySelectorAll('[data-open-modal]').forEach(btn => {
@@ -843,7 +912,7 @@
 
     logAuto.addEventListener('change', () => {
       if (logAuto.checked) {
-        logsInterval = setInterval(updateLogs, 4000);
+        logsInterval = setInterval(updateLogs, logsIntervalMs);
       } else {
         clearInterval(logsInterval);
       }

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -526,6 +526,20 @@
     let homeLogContainerId = null;
     let homeLogInterval = null;
     let homeLogBuffer = '';
+    const overviewDefaults = {
+      overviewIntervalMs: 5000,
+      maxSamples: 20,
+      homeLogIntervalMs: 4000,
+    };
+    const overviewPerformance = {
+      overviewIntervalMs: 10000,
+      maxSamples: 12,
+      homeLogIntervalMs: 7000,
+    };
+    let overviewIntervalMs = overviewDefaults.overviewIntervalMs;
+    let overviewMaxSamples = overviewDefaults.maxSamples;
+    let overviewInterval = null;
+    let homeLogIntervalMs = overviewDefaults.homeLogIntervalMs;
 
     const escapeLogHtml = (str) =>
       (str || '')
@@ -595,7 +609,7 @@
     const startHomeLogLoop = () => {
       clearInterval(homeLogInterval);
       if (homeLogAuto.checked && homeLogContainerId) {
-        homeLogInterval = setInterval(updateHomeLogs, 4000);
+        homeLogInterval = setInterval(updateHomeLogs, homeLogIntervalMs);
       }
     };
 
@@ -802,7 +816,8 @@
     });
 
     function trimData(chart) {
-      if (chart.data.labels.length > 20) {
+      const maxSamples = Math.max(overviewMaxSamples, 5);
+      while (chart.data.labels.length > maxSamples) {
         chart.data.labels.shift();
         chart.data.datasets.forEach((dataset) => dataset.data.shift());
       }
@@ -902,6 +917,11 @@
       });
     }
 
+    const startOverviewPolling = () => {
+      clearInterval(overviewInterval);
+      overviewInterval = setInterval(refreshOverview, overviewIntervalMs);
+    };
+
     async function refreshOverview() {
       try {
         const res = await fetch('/api/overview');
@@ -916,7 +936,16 @@
 
     applySummary(initialData.summary);
     applyStacks(initialData.stacks);
-    setInterval(refreshOverview, 5000);
+    startOverviewPolling();
+    window.registerPerformanceHandler?.((enabled) => {
+      overviewIntervalMs = enabled ? overviewPerformance.overviewIntervalMs : overviewDefaults.overviewIntervalMs;
+      overviewMaxSamples = enabled ? overviewPerformance.maxSamples : overviewDefaults.maxSamples;
+      homeLogIntervalMs = enabled ? overviewPerformance.homeLogIntervalMs : overviewDefaults.homeLogIntervalMs;
+      if (homeLogInterval) {
+        startHomeLogLoop();
+      }
+      startOverviewPolling();
+    });
   </script>
 </body>
 </html>

--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -37,6 +37,16 @@
           <span>Uptime</span>
           <strong>{{ system_info.uptime }}</strong>
         </div>
+        <div class="settings-row settings-row-toggle">
+          <div>
+            <span>Modalità prestazioni</span>
+            <p class="settings-hint">Riduci carico e polling automatico.</p>
+          </div>
+          <div class="switch" title="Riduce il carico iniziale e le frequenze di refresh">
+            <input type="checkbox" id="performance-mode-toggle" />
+            <span class="slider"></span>
+          </div>
+        </div>
         <div class="settings-safe">
           <div>
             <div class="settings-row">

--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -14,6 +14,7 @@
     const backendRefreshBtn = document.getElementById('backend-status-refresh-btn');
     const backendCloseBtn = document.getElementById('backend-status-close-btn');
     const safeModeToggleEl = document.getElementById('safeModeToggle');
+    const performanceModeToggleEl = document.getElementById('performance-mode-toggle');
     const safeConfirmState = {
       modal: null,
       message: null,
@@ -22,6 +23,9 @@
       pendingForm: null,
     };
     let safeModeEnabled = (document.body.dataset.safeMode || '0') === '1';
+    window.d2haSettings = window.d2haSettings || { performanceMode: false };
+    window.d2haRuntime = window.d2haRuntime || { performanceHandlers: [] };
+    const performanceState = window.d2haSettings;
     let currentNotifications = initialNotifications;
     let dismissedNotifications = {};
     let clockInterval = null;
@@ -47,6 +51,40 @@
       clockInterval = setInterval(updateClock, 1000);
     }
 
+    function syncPerformanceToggle(enabled) {
+      if (performanceModeToggleEl) {
+        performanceModeToggleEl.checked = enabled;
+      }
+    }
+
+    function initPerformanceMode() {
+      let storedPreference = null;
+      try {
+        storedPreference = localStorage.getItem('d2ha.performanceMode');
+      } catch (err) {
+        storedPreference = null;
+      }
+
+      const enabled = storedPreference === 'true';
+      performanceState.performanceMode = enabled;
+      syncPerformanceToggle(enabled);
+
+      if (performanceModeToggleEl) {
+        performanceModeToggleEl.addEventListener('change', () => {
+          const nextValue = performanceModeToggleEl.checked;
+          performanceState.performanceMode = nextValue;
+          try {
+            localStorage.setItem('d2ha.performanceMode', nextValue ? 'true' : 'false');
+          } catch (err) {
+            console.error('Unable to persist performance mode', err);
+          }
+          applyPerformanceMode(nextValue);
+        });
+      }
+
+      applyPerformanceMode(enabled);
+    }
+
     function updateSafeModeState(enabled) {
       safeModeEnabled = !!enabled;
       document.body.dataset.safeMode = safeModeEnabled ? '1' : '0';
@@ -55,6 +93,30 @@
       }
       window.d2haSafeMode = { enabled: safeModeEnabled };
       document.dispatchEvent(new CustomEvent('safe-mode-changed', { detail: { enabled: safeModeEnabled } }));
+    }
+
+    function registerPerformanceHandler(handler) {
+      if (typeof handler !== 'function') return;
+      window.d2haRuntime.performanceHandlers.push(handler);
+      try {
+        handler(!!performanceState.performanceMode);
+      } catch (err) {
+        console.error('Performance handler failed during registration', err);
+      }
+    }
+
+    function applyPerformanceMode(enabled) {
+      performanceState.performanceMode = !!enabled;
+      window.d2haRuntime.performanceHandlers.forEach((handler) => {
+        try {
+          handler(performanceState.performanceMode);
+        } catch (err) {
+          console.error('Performance handler failed', err);
+        }
+      });
+      document.dispatchEvent(
+        new CustomEvent('performance-mode-changed', { detail: { enabled: performanceState.performanceMode } })
+      );
     }
 
     function updateBackendStatus(durationMs) {
@@ -444,6 +506,9 @@
       );
     }
 
+  window.registerPerformanceHandler = registerPerformanceHandler;
+  window.applyPerformanceMode = applyPerformanceMode;
+  initPerformanceMode();
   loadDismissedNotifications();
   updateSafeModeState(safeModeEnabled);
   renderNotificationList(currentNotifications);

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -226,6 +226,8 @@
   }
   .settings-body { padding: 10px 14px; display: flex; flex-direction: column; gap: 10px; }
   .settings-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .settings-row-toggle { align-items: flex-start; gap: 14px; }
+  .settings-row-toggle .switch { margin-top: 4px; }
   .settings-row strong { color: var(--text); }
   .settings-safe { border-top: 1px solid var(--border); padding-top: 8px; }
   .settings-hint { margin: 4px 0 0; color: var(--muted); font-size: 0.85rem; }

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -50,6 +50,9 @@
     .btn-full-update { background: linear-gradient(135deg, #1fb1ff, #4bd1ff); color:#04101c; font-weight: 800; letter-spacing: 0.01em; }
     .btn-full-update:hover { filter: brightness(1.1); }
     .small { font-size: 0.75rem; color: #aaa; }
+    .performance-hint { display:none; margin-top: 8px; padding: 10px 12px; border-radius: 12px; background: rgba(255,255,255,0.04); border:1px dashed var(--border); align-items: center; gap: 12px; }
+    .performance-hint.visible { display: flex; justify-content: space-between; flex-wrap: wrap; }
+    .performance-hint .hint-title { font-weight: 800; margin-bottom: 4px; display: block; }
     code { font-family: "JetBrains Mono", "Fira Code", Consolas, monospace; font-size: 0.75rem; }
     .stack-card { margin-bottom: 12px; }
     .stack-header { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:10px 12px; border:1px solid var(--border); border-radius:12px; background: linear-gradient(135deg, #141927, #0f131d); cursor:pointer; box-shadow: var(--shadow); }
@@ -99,6 +102,13 @@
     <div class="card">
       {% set total = stacks | map(attribute='containers') | map('length') | sum %}
       <div class="muted">{{ total }} container analizzati · {{ summary.images }} immagini installate</div>
+      <div class="performance-hint" id="updates-performance-hint">
+        <div>
+          <span class="hint-title">Modalità prestazioni attiva</span>
+          <p class="small">Per ridurre il carico, la scansione automatica è disattivata. Avvia manualmente quando serve.</p>
+        </div>
+        <button class="btn btn-ghost" type="button" id="updates-scan-btn">Scansiona aggiornamenti</button>
+      </div>
     </div>
     {% for stack in stacks %}
       <section class="card stack-card" data-stack="{{ stack.name }}">
@@ -220,6 +230,13 @@
       up_to_date: 'status-up-to-date',
       unknown: 'status-unknown'
     };
+    const updatesHint = document.getElementById('updates-performance-hint');
+    const manualScanBtn = document.getElementById('updates-scan-btn');
+    const pollingDefaults = { intervalMs: 20000 };
+    const pollingPerformance = { intervalMs: 45000 };
+    let refreshIntervalMs = pollingDefaults.intervalMs;
+    let refreshTimer = null;
+    let autoScanEnabled = !(window.d2haSettings?.performanceMode);
 
     function toggleStack(card) {
       card.classList.toggle('collapsed');
@@ -292,9 +309,25 @@
       const rows = Array.from(document.querySelectorAll('.container-row'));
       rows.forEach(row => refreshRow(row));
     }
+    function startUpdatesPolling() {
+      clearInterval(refreshTimer);
+      if (!autoScanEnabled) return;
+      scheduleRefresh();
+      refreshTimer = setInterval(scheduleRefresh, refreshIntervalMs);
+    }
 
-    setInterval(scheduleRefresh, 20000);
-    scheduleRefresh();
+    manualScanBtn?.addEventListener('click', () => {
+      scheduleRefresh();
+    });
+
+    window.registerPerformanceHandler?.((enabled) => {
+      refreshIntervalMs = enabled ? pollingPerformance.intervalMs : pollingDefaults.intervalMs;
+      autoScanEnabled = !enabled;
+      updatesHint?.classList.toggle('visible', enabled);
+      startUpdatesPolling();
+    });
+
+    startUpdatesPolling();
 
     const modal = document.getElementById('confirm-modal');
     const messageEl = document.getElementById('confirm-message');


### PR DESCRIPTION
## Summary
- add a persistent Performance Mode toggle in the settings dropdown and expose a shared handler API
- slow down polling and reduce chart sample sizes on the home and container views when Performance Mode is enabled
- disable automatic update scans in Performance Mode and show a manual scan action with contextual messaging

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211a4d4680832dbfcf1c86ef6550e2)