### PR TITLE
Add onboarding authentication with 2FA support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Chiave segreta Flask (usa un valore robusto in produzione)
+D2HA_SECRET_KEY=change_me_with_a_secure_value
+# Username iniziale opzionale (password predefinita = admin, cambia al primo avvio)
+D2HA_ADMIN_USERNAME=admin
+
+# Configurazione MQTT (opzionale)
+MQTT_BROKER=localhost
+MQTT_PORT=1883
+MQTT_USERNAME=
+MQTT_PASSWORD=
+MQTT_BASE_TOPIC=d2ha_server
+MQTT_DISCOVERY_PREFIX=homeassistant
+MQTT_NODE_ID=d2ha_server
+MQTT_STATE_INTERVAL=5

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+d2ha/auth_config.json
+.env

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ Popup di dettaglio con:
 
 ---
 
+## 🔐 Autenticazione e onboarding
+
+- **Credenziali iniziali:** `admin / admin`.
+- Al **primo login** viene avviata una procedura guidata:
+  - scelta di una nuova password (obbligatoria) e, se vuoi, di un nuovo username;
+  - scelta se abilitare subito la **2FA TOTP** (Google Authenticator, Aegis, ecc.) o rimandare.
+- La configurazione di sicurezza viene salvata nel file JSON `d2ha/auth_config.json` (creato automaticamente con permessi ristretti al primo avvio).
+- Variabili utili:
+  - `D2HA_SECRET_KEY` per impostare la chiave di sessione Flask (obbligatorio in produzione);
+  - `D2HA_ADMIN_USERNAME` per personalizzare l'username iniziale prima del primo avvio.
+
+> Suggerimento: esegui D2HA dietro a un reverse proxy HTTPS e considera la 2FA indispensabile se l'interfaccia è esposta in rete.
+
+---
+
 ## 🗂️ Struttura del progetto
 
 ```

--- a/d2ha/requirements.txt
+++ b/d2ha/requirements.txt
@@ -2,3 +2,4 @@ flask
 docker
 paho-mqtt
 python-dotenv
+pyotp

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -26,6 +26,7 @@
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
     .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .meta { color: var(--muted); font-size:0.9rem; }
@@ -68,6 +69,11 @@
     .col-image { width: 220px; }
     .col-status { width: 140px; }
     .col-pref { width: 260px; }
+    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
+    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
     @media(max-width: 960px) {
       table { min-width: 720px; }
       th, td { font-size:0.82rem; }
@@ -88,8 +94,19 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+      <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      <div class="flash-container">
+        {% for category, msg in messages %}
+          <div class="flash {{ category }}">{{ msg }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
 
   <main>
     <section class="card">

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -26,6 +26,7 @@
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
     .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 16px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .stack-card { display:flex; flex-direction:column; gap:12px; }
@@ -131,6 +132,11 @@
     .toast-success { border-color: rgba(124,255,195,0.25); }
     .toast-error { border-color: rgba(255,138,122,0.25); }
     .toast-warning { border-color: rgba(255,213,79,0.35); }
+    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
+    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
     @media(max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -154,8 +160,19 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+      <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      <div class="flash-container">
+        {% for category, msg in messages %}
+          <div class="flash {{ category }}">{{ msg }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
 
   <main>
     <div class="card">

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -42,6 +42,7 @@
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
     .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .filters { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
@@ -66,6 +67,11 @@
     .muted { color: var(--muted); font-size:0.85rem; }
     .badge { padding:4px 8px; border-radius:8px; background: rgba(255,255,255,0.05); border:1px solid var(--border); font-size:0.8rem; }
     .empty { padding:18px; text-align:center; color: var(--muted); }
+    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
+    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
     @media (max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -89,8 +95,19 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+      <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      <div class="flash-container">
+        {% for category, msg in messages %}
+          <div class="flash {{ category }}">{{ msg }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
 
   <main>
     <section class="card filters">

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -81,6 +81,12 @@
       color: #0c121e;
       box-shadow: 0 6px 18px rgba(49,196,255,0.35);
     }
+    .logout-link {
+      margin-left: auto;
+      background: linear-gradient(135deg, #7cffc3, #31c4ff);
+      color: #0c121e;
+      box-shadow: 0 6px 18px rgba(124,255,195,0.25);
+    }
     .layout {
       display: grid;
       grid-template-columns: 320px 1fr;
@@ -335,6 +341,23 @@
       border-radius: 50%;
       display: inline-block;
     }
+    .flash-container {
+      margin: 12px 18px 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .flash {
+      padding: 12px 14px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: rgba(255,255,255,0.04);
+      color: var(--text);
+      box-shadow: var(--shadow);
+    }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
     @media (max-width: 960px) {
       .layout { grid-template-columns: 1fr; }
     }
@@ -355,8 +378,19 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+      <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      <div class="flash-container">
+        {% for category, msg in messages %}
+          <div class="flash {{ category }}">{{ msg }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
 
   <div class="layout">
     <aside>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -26,6 +26,7 @@
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
     .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; }
@@ -41,6 +42,11 @@
     .btn:hover { background:#31394e; transform: translateY(-1px); }
     .btn-danger { background:#b71c1c; }
     .btn:disabled { opacity:0.4; cursor:not-allowed; transform:none; }
+    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
+    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
     @media(max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -64,8 +70,19 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+      <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      <div class="flash-container">
+        {% for category, msg in messages %}
+          <div class="flash {{ category }}">{{ msg }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
 
   <main>
     <div class="card">

--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA – Login</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #151924;
+      --panel-2: #1b2131;
+      --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --text: #e7ecf4;
+      --muted: #9aa7bd;
+      --border: rgba(255,255,255,0.08);
+      --shadow: 0 10px 30px rgba(0,0,0,0.45);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 25%),
+                  radial-gradient(circle at 88% 12%, rgba(124,255,195,0.06), transparent 22%),
+                  var(--bg);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 18px;
+    }
+    .card {
+      width: min(460px, 100%);
+      background: linear-gradient(160deg, rgba(49,196,255,0.08), rgba(124,255,195,0.06)), var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px 22px;
+      box-shadow: var(--shadow);
+    }
+    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
+    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
+    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
+    label { font-weight: 700; color: var(--text); font-size: 0.9rem; }
+    input {
+      width: 100%;
+      padding: 10px 12px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      font-size: 1rem;
+    }
+    .btn {
+      margin-top: 6px;
+      padding: 12px;
+      border: none;
+      border-radius: 12px;
+      background: linear-gradient(135deg, #1b87f1, #31c4ff);
+      color: #0c121e;
+      font-weight: 800;
+      cursor: pointer;
+      box-shadow: 0 8px 18px rgba(49,196,255,0.35);
+    }
+    .btn:hover { filter: brightness(1.05); }
+    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .hint { font-size: 0.9rem; color: var(--muted); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>D2HA • Accesso</h1>
+    <p>Accedi con le credenziali amministrative. Al primo login con <strong>admin / admin</strong> ti guideremo in un rapido setup sicuro.</p>
+
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        <div class="flash-container">
+          {% for category, msg in messages %}
+            <div class="flash {{ category }}">{{ msg }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    <form method="post" autocomplete="off">
+      <div>
+        <label for="username">Username</label>
+        <input type="text" id="username" name="username" required />
+      </div>
+      <div>
+        <label for="password">Password</label>
+        <input type="password" id="password" name="password" required />
+      </div>
+      {% if two_factor %}
+      <div>
+        <label for="token">Codice 2FA (6 cifre)</label>
+        <input type="text" id="token" name="token" pattern="\d{6}" inputmode="numeric" autocomplete="one-time-code" />
+        <p class="hint">Hai attivato l'autenticazione a due fattori. Inserisci il codice temporaneo dall'app Authenticator.</p>
+      </div>
+      {% endif %}
+      <button type="submit" class="btn">Entra</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/d2ha/templates/setup_2fa.html
+++ b/d2ha/templates/setup_2fa.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA – Configura 2FA</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #151924;
+      --panel-2: #1b2131;
+      --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --text: #e7ecf4;
+      --muted: #9aa7bd;
+      --border: rgba(255,255,255,0.08);
+      --shadow: 0 10px 30px rgba(0,0,0,0.45);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
+                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
+                  var(--bg);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 18px;
+    }
+    .card {
+      width: min(520px, 100%);
+      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px 22px;
+      box-shadow: var(--shadow);
+    }
+    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
+    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    .secret-box { background: var(--panel-2); border:1px solid var(--border); border-radius: 12px; padding: 12px; font-family: "JetBrains Mono", monospace; margin: 8px 0; }
+    .actions { display: flex; gap: 12px; flex-wrap: wrap; }
+    .btn { padding: 12px 16px; border-radius: 12px; border: none; font-weight: 800; cursor: pointer; }
+    .btn-primary { background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; box-shadow: 0 8px 18px rgba(49,196,255,0.35); }
+    .btn-secondary { background: rgba(255,255,255,0.06); color: var(--text); border:1px solid var(--border); }
+    input[type="text"] { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
+    .flash-container { margin: 12px 0; display: flex; flex-direction: column; gap: 8px; }
+    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="pill">Passo 2</div>
+    <h1>Autenticazione a due fattori</h1>
+    <p>Aggiungi un secondo fattore di sicurezza: ad ogni login, oltre a username e password, ti verrà chiesto un codice temporaneo generato sul tuo smartphone.</p>
+    <p>Consigliato se l'interfaccia è accessibile da internet o da utenti non fidati.</p>
+
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        <div class="flash-container">
+          {% for category, msg in messages %}
+            <div class="flash {{ category }}">{{ msg }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    <div class="note">
+      <p>1. Apri Google Authenticator, Aegis o app simile.</p>
+      <p>2. Aggiungi un nuovo account scansionando il QR o inserendo il codice segreto.</p>
+      <p>3. Inserisci un codice a 6 cifre per confermare.</p>
+    </div>
+
+    <div class="secret-box">{{ secret }}</div>
+    <p class="muted" style="color: var(--muted); word-break: break-all;">URI: {{ provisioning_uri }}</p>
+
+    <form method="post" autocomplete="off" style="margin-top:12px; display:flex; flex-direction:column; gap:10px;">
+      <label for="token">Codice 2FA</label>
+      <input type="text" id="token" name="token" pattern="\d{6}" inputmode="numeric" autocomplete="one-time-code" />
+      <div class="actions">
+        <button class="btn btn-primary" type="submit" name="choice" value="enable">Abilita 2FA</button>
+        <button class="btn btn-secondary" type="submit" name="choice" value="skip">Salta per ora</button>
+      </div>
+    </form>
+  </div>
+</body>
+</html>

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA – Primo accesso</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #151924;
+      --panel-2: #1b2131;
+      --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --text: #e7ecf4;
+      --muted: #9aa7bd;
+      --border: rgba(255,255,255,0.08);
+      --shadow: 0 10px 30px rgba(0,0,0,0.45);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
+                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
+                  var(--bg);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 18px;
+    }
+    .card {
+      width: min(520px, 100%);
+      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px 22px;
+      box-shadow: var(--shadow);
+    }
+    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
+    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
+    label { font-weight: 700; color: var(--text); font-size: 0.9rem; }
+    input { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
+    .btn { margin-top: 6px; padding: 12px; border: none; border-radius: 12px; background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: 0 8px 18px rgba(49,196,255,0.35); }
+    .btn:hover { filter: brightness(1.05); }
+    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    ul { margin: 0 0 10px 20px; color: var(--muted); }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="pill">Primo avvio</div>
+    <h1>Proteggi il tuo accesso</h1>
+    <p>Stai accedendo con le credenziali predefinite <strong>admin / admin</strong>. Per sicurezza devi scegliere una nuova password (e, se vuoi, anche un nuovo username). La vecchia password smetterà di funzionare.</p>
+    <p>Consigli rapidi:</p>
+    <ul>
+      <li>Usa almeno 10 caratteri con lettere, numeri e simboli.</li>
+      <li>Evita parole comuni o password già usate altrove.</li>
+      <li>L'username può restare "{{ current_username }}" oppure puoi personalizzarlo.</li>
+    </ul>
+
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        <div class="flash-container">
+          {% for category, msg in messages %}
+            <div class="flash {{ category }}">{{ msg }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    <form method="post" autocomplete="off">
+      <div>
+        <label for="new_username">Nuovo username (facoltativo)</label>
+        <input type="text" id="new_username" name="new_username" placeholder="{{ current_username }}" />
+      </div>
+      <div>
+        <label for="new_password">Nuova password</label>
+        <input type="password" id="new_password" name="new_password" required />
+      </div>
+      <div>
+        <label for="new_password_confirm">Conferma password</label>
+        <input type="password" id="new_password_confirm" name="new_password_confirm" required />
+      </div>
+      <button type="submit" class="btn">Continua</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -26,6 +26,7 @@
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
     .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
@@ -80,6 +81,11 @@
     .confirm-title { margin:0; font-size:1rem; }
     .confirm-actions { display:flex; justify-content:flex-end; gap:8px; }
     .btn-ghost { background: rgba(255,255,255,0.04); color: var(--text); }
+    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
+    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
     @media(max-width: 1100px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -104,8 +110,19 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
+      <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>
+
+  {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+      <div class="flash-container">
+        {% for category, msg in messages %}
+          <div class="flash {{ category }}">{{ msg }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
 
   <main>
     <div class="card">


### PR DESCRIPTION
## Summary
- add JSON-based auth store with default admin credentials and Flask session security
- enforce login/onboarding flow with username/password change and optional TOTP 2FA
- introduce dedicated login/setup templates, flash messaging, and logout navigation plus env sample updates

## Testing
- python -m py_compile d2ha/app.py d2ha/auth_store.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692268601340832d80d08094c92433f8)