### PR TITLE
Show onboarding login hint only before setup

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -227,7 +227,11 @@ def login():
 
         flash("Invalid credentials or 2FA code", "error")
 
-    return render_template("login.html", two_factor=two_factor)
+    return render_template(
+        "login.html",
+        two_factor=two_factor,
+        show_onboarding_hint=not bool(config.get("onboarding_done")),
+    )
 
 
 @app.route("/logout")

--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -73,7 +73,9 @@
 <body>
   <div class="card">
     <h1>D2HA • Login</h1>
+    {% if show_onboarding_hint %}
     <p>Accedi con le credenziali amministrative. Al primo login con <strong>admin / admin</strong> ti guideremo in un rapido setup sicuro.</p>
+    {% endif %}
 
     {% with messages = get_flashed_messages(with_categories=True) %}
       {% if messages %}


### PR DESCRIPTION
## Summary
- show the admin credential hint only when onboarding has not been completed
- pass onboarding completion status to the login template to toggle the message

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69226f0e5518832db6d04ce1d2f10efb)