### PR TITLE
Fix security settings page notification styling

### DIFF
--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -146,6 +146,7 @@
     .secret-chip { padding: 6px 10px; border-radius: 10px; background: rgba(255,255,255,0.06); border: 1px solid var(--border); display: inline-block; }
     @media (max-width: 700px) { .qr-box { grid-template-columns: 1fr; } nav { justify-content: flex-start; } }
   </style>
+  {% include 'partials/notifications_styles.html' %}
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- include notification styles partial on the security settings page so header widgets render correctly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692274be13a4832dabec69a4bc5a5a15)