### PR TITLE
Extend onboarding for modes and autodiscovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,15 @@ Popup di dettaglio con:
 ## 🔐 Autenticazione e onboarding
 
 - **Credenziali iniziali:** `admin / admin`.
-- Al **primo login** viene avviata una procedura guidata:
-  - scelta di una nuova password (obbligatoria) e, se vuoi, di un nuovo username;
-  - scelta se abilitare subito la **2FA TOTP** (Google Authenticator, Aegis, ecc.) o rimandare.
+- Al **primo login** viene avviata una procedura guidata che copre quattro passi:
+  1. scelta di una nuova password (obbligatoria) e, se vuoi, di un nuovo username;
+  2. abilita o salta la **2FA TOTP** (Google Authenticator, Aegis, ecc.);
+  3. configurazione iniziale di **Modalità sicura** (on di default) e **Modalità prestazioni** (off di default);
+  4. scelta del comportamento iniziale per l'autodiscovery MQTT: esporre o meno tutte le entità di default.
+- Tutte le scelte restano modificabili dopo il primo avvio:
+  - credenziali e 2FA dalla pagina Sicurezza;
+  - Modalità sicura / prestazioni tramite l'icona a forma di ingranaggio nell'header;
+  - entità MQTT dalla pagina Autodiscovery.
 - La configurazione di sicurezza viene salvata nel file JSON `d2ha/auth_config.json` (creato automaticamente con permessi ristretti al primo avvio).
 - Variabili utili:
   - `D2HA_SECRET_KEY` per impostare la chiave di sessione Flask (obbligatorio in produzione);

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -81,7 +81,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Autodiscovery</span></h1>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -147,7 +147,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Container</span></h1>

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -82,7 +82,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Eventi</span></h1>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -365,7 +365,7 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   {% include 'partials/notifications_styles.html' %}
 </head>
-  <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
+  <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
     <header>
       <div class="brand-line">
         <h1>D2HA <span class="brand-pill">Webserver</span></h1>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -57,7 +57,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Immagini</span></h1>

--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -23,7 +23,8 @@
       pendingForm: null,
     };
     let safeModeEnabled = (document.body.dataset.safeMode || '0') === '1';
-    window.d2haSettings = window.d2haSettings || { performanceMode: false };
+    const initialPerformanceMode = (document.body?.dataset?.performanceMode || '0') === '1';
+    window.d2haSettings = window.d2haSettings || { performanceMode: initialPerformanceMode };
     window.d2haRuntime = window.d2haRuntime || { performanceHandlers: [] };
     const performanceState = window.d2haSettings;
     let currentNotifications = initialNotifications;
@@ -57,32 +58,52 @@
       }
     }
 
-    function initPerformanceMode() {
-      let storedPreference = null;
-      try {
-        storedPreference = localStorage.getItem('d2ha.performanceMode');
-      } catch (err) {
-        storedPreference = null;
-      }
+    function updatePerformanceMode(enabled) {
+      performanceState.performanceMode = !!enabled;
+      syncPerformanceToggle(performanceState.performanceMode);
+      applyPerformanceMode(performanceState.performanceMode);
+    }
 
-      const enabled = storedPreference === 'true';
-      performanceState.performanceMode = enabled;
-      syncPerformanceToggle(enabled);
+    async function loadPerformanceMode() {
+      try {
+        const res = await fetch('/api/performance_mode');
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        updatePerformanceMode(!!data.enabled);
+      } catch (err) {
+        console.warn('Unable to load performance mode from backend', err);
+      }
+    }
+
+    async function persistPerformanceMode(enabled) {
+      try {
+        const res = await fetch('/api/performance_mode', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled }),
+        });
+        if (!res.ok) throw new Error('Request failed');
+        const data = await res.json();
+        updatePerformanceMode(!!data.enabled);
+      } catch (err) {
+        console.error('Impossibile aggiornare la modalità prestazioni', err);
+        if (performanceModeToggleEl) {
+          performanceModeToggleEl.checked = performanceState.performanceMode;
+        }
+        alert('Impossibile aggiornare la modalità prestazioni');
+      }
+    }
+
+    function initPerformanceMode() {
+      updatePerformanceMode(initialPerformanceMode);
 
       if (performanceModeToggleEl) {
         performanceModeToggleEl.addEventListener('change', () => {
-          const nextValue = performanceModeToggleEl.checked;
-          performanceState.performanceMode = nextValue;
-          try {
-            localStorage.setItem('d2ha.performanceMode', nextValue ? 'true' : 'false');
-          } catch (err) {
-            console.error('Unable to persist performance mode', err);
-          }
-          applyPerformanceMode(nextValue);
+          persistPerformanceMode(performanceModeToggleEl.checked);
         });
       }
 
-      applyPerformanceMode(enabled);
+      loadPerformanceMode();
     }
 
     function updateSafeModeState(enabled) {

--- a/d2ha/templates/setup_autodiscovery.html
+++ b/d2ha/templates/setup_autodiscovery.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA – Autodiscovery MQTT</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #151924;
+      --panel-2: #1b2131;
+      --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --text: #e7ecf4;
+      --muted: #9aa7bd;
+      --border: rgba(255,255,255,0.08);
+      --shadow: 0 10px 30px rgba(0,0,0,0.45);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
+                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
+                  var(--bg);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 18px;
+    }
+    .card {
+      width: min(520px, 100%);
+      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px 22px;
+      box-shadow: var(--shadow);
+    }
+    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
+    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
+    label { font-weight: 700; color: var(--text); font-size: 0.95rem; display:block; }
+    input[type="radio"] { width: 18px; height: 18px; accent-color: var(--accent); }
+    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
+    button:hover { filter: brightness(1.05); }
+    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
+    .hint { font-size: 0.85rem; opacity: 0.8; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="pill">Primo avvio</div>
+    <h1>Autodiscovery MQTT e Home Assistant</h1>
+    <p>Docker2HomeAssistant può esporre automaticamente entità MQTT verso Home Assistant tramite autodiscovery.</p>
+    <p>Dalla pagina autodiscovery potrai sempre selezionare con precisione quali entità pubblicare. Qui puoi scegliere il comportamento iniziale per le entità di default.</p>
+
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        <div class="flash-container">
+          {% for category, msg in messages %}
+            <div class="flash {{ category }}">{{ msg }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    <form method="post">
+      <label style="margin-bottom:8px;">
+        <input type="radio" name="autodiscovery_choice" value="enable_all" {% if mqtt_default_entities_enabled %}checked{% endif %}>
+        <strong>Abilita tutte le entità MQTT di default</strong><br>
+        <span class="hint">Consigliato se vuoi vedere subito tutti i dati in Home Assistant. Potrai disattivare le entità che non ti servono dalla pagina autodiscovery.</span>
+      </label>
+
+      <label style="margin-top:8px;">
+        <input type="radio" name="autodiscovery_choice" value="disable_all" {% if not mqtt_default_entities_enabled %}checked{% endif %}>
+        <strong>Non abilitare nessuna entità per ora</strong><br>
+        <span class="hint">Consigliato se preferisci mantenere Home Assistant pulito e abilitare manualmente solo le entità che ti interessano, dalla pagina autodiscovery.</span>
+      </label>
+
+      <button type="submit" style="margin-top:16px;">Completa configurazione</button>
+    </form>
+
+    <p class="hint" style="margin-top:12px;">Potrai sempre modificare queste scelte in seguito dalla pagina Autodiscovery.</p>
+  </div>
+</body>
+</html>

--- a/d2ha/templates/setup_modes.html
+++ b/d2ha/templates/setup_modes.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA – Modalità del sistema</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #151924;
+      --panel-2: #1b2131;
+      --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --text: #e7ecf4;
+      --muted: #9aa7bd;
+      --border: rgba(255,255,255,0.08);
+      --shadow: 0 10px 30px rgba(0,0,0,0.45);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
+                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
+                  var(--bg);
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 18px;
+    }
+    .card {
+      width: min(520px, 100%);
+      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      padding: 20px 22px;
+      box-shadow: var(--shadow);
+    }
+    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
+    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
+    label { font-weight: 700; color: var(--text); font-size: 0.95rem; }
+    input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); }
+    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
+    button:hover { filter: brightness(1.05); }
+    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
+    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
+    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
+    .hint { font-size: 0.85rem; opacity: 0.8; margin-top: -6px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="pill">Primo avvio</div>
+    <h1>Modalità del sistema</h1>
+    <p>Queste opzioni ti aiutano a bilanciare sicurezza e prestazioni. Puoi sempre modificarle in seguito dal pulsante con l'icona dell'ingranaggio in alto a destra.</p>
+
+    {% with messages = get_flashed_messages(with_categories=True) %}
+      {% if messages %}
+        <div class="flash-container">
+          {% for category, msg in messages %}
+            <div class="flash {{ category }}">{{ msg }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    <form method="post">
+      <label style="display:flex;align-items:center;gap:8px;">
+        <input type="checkbox" name="safe_mode_enabled" {% if safe_mode_enabled %}checked{% endif %}>
+        <span><strong>Modalità sicura</strong> (consigliata, attiva di default)</span>
+      </label>
+      <p class="hint">Quando attiva, alcune modifiche critiche richiederanno conferma o verranno bloccate.</p>
+
+      <label style="display:flex;align-items:center;gap:8px;margin-top:12px;">
+        <input type="checkbox" name="performance_mode_enabled" {% if performance_mode_enabled %}checked{% endif %}>
+        <span><strong>Modalità prestazioni</strong></span>
+      </label>
+      <p class="hint">Riduce il carico sul server e il polling automatico. Utile su hardware poco potente o connessioni lente.</p>
+
+      <button type="submit">Continua</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -97,7 +97,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}">
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Aggiornamenti</span></h1>


### PR DESCRIPTION
## Summary
- persist safe mode and performance mode in the shared auth config and expose a backend API so UI toggles use the same source of truth
- extend the onboarding wizard with new steps to configure safe/performance modes and MQTT autodiscovery defaults, including templates and final onboarding completion
- add a bulk autodiscovery preference helper, propagate defaults to existing configs, and document the full four-step onboarding flow

## Testing
- python -m compileall d2ha


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692277d38708832d930241172055b394)