### PR TITLE
Remove onboarding pills and guard autodiscovery setup

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -424,15 +424,32 @@ def setup_autodiscovery():
             config["mqtt_default_entities_enabled"] = enable_all
             save_auth_config(config)
 
-            apply_autodiscovery_default_choice(enable_all)
+            autodiscovery_applied = True
+            try:
+                apply_autodiscovery_default_choice(enable_all)
+            except Exception:
+                autodiscovery_applied = False
+                app.logger.exception(
+                    "Failed to apply autodiscovery defaults during onboarding"
+                )
+                flash(
+                    "Impossibile applicare automaticamente l'autodiscovery MQTT. Puoi riprovare dalla pagina Autodiscovery.",
+                    "error",
+                )
 
             config["onboarding_done"] = True
             save_auth_config(config)
 
-            flash(
-                "Configurazione iniziale completata. Potrai modificare queste impostazioni in qualsiasi momento.",
-                "success",
-            )
+            if autodiscovery_applied:
+                flash(
+                    "Configurazione iniziale completata. Potrai modificare queste impostazioni in qualsiasi momento.",
+                    "success",
+                )
+            else:
+                flash(
+                    "Configurazione iniziale completata, ma alcune impostazioni MQTT potrebbero richiedere un nuovo tentativo dalla pagina Autodiscovery.",
+                    "info",
+                )
             return redirect(url_for("home"))
 
     return render_template(

--- a/d2ha/templates/setup_2fa.html
+++ b/d2ha/templates/setup_2fa.html
@@ -61,7 +61,6 @@
 </head>
 <body>
   <div class="card">
-    <div class="pill">Passo 2</div>
     <h1>Autenticazione a due fattori</h1>
     <p>Aggiungi un secondo fattore di sicurezza: ad ogni login, oltre a username e password, ti verrà chiesto un codice temporaneo generato sul tuo smartphone.</p>
     <p>Consigliato se l'interfaccia è accessibile da internet o da utenti non fidati.</p>

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -55,7 +55,6 @@
 </head>
 <body>
   <div class="card">
-    <div class="pill">Primo avvio</div>
     <h1>Proteggi il tuo accesso</h1>
     <p>Stai accedendo con le credenziali predefinite <strong>admin / admin</strong>. Per sicurezza devi scegliere una nuova password (e, se vuoi, anche un nuovo username). La vecchia password smetterà di funzionare.</p>
     <p>Consigli rapidi:</p>

--- a/d2ha/templates/setup_autodiscovery.html
+++ b/d2ha/templates/setup_autodiscovery.html
@@ -55,7 +55,6 @@
 </head>
 <body>
   <div class="card">
-    <div class="pill">Primo avvio</div>
     <h1>Autodiscovery MQTT e Home Assistant</h1>
     <p>Docker2HomeAssistant può esporre automaticamente entità MQTT verso Home Assistant tramite autodiscovery.</p>
     <p>Dalla pagina autodiscovery potrai sempre selezionare con precisione quali entità pubblicare. Qui puoi scegliere il comportamento iniziale per le entità di default.</p>

--- a/d2ha/templates/setup_modes.html
+++ b/d2ha/templates/setup_modes.html
@@ -54,7 +54,6 @@
 </head>
 <body>
   <div class="card">
-    <div class="pill">Primo avvio</div>
     <h1>Modalità del sistema</h1>
     <p>Queste opzioni ti aiutano a bilanciare sicurezza e prestazioni. Puoi sempre modificarle in seguito dal pulsante con l'icona dell'ingranaggio in alto a destra.</p>
 


### PR DESCRIPTION
## Summary
- remove the onboarding pill labels from the setup templates
- guard the autodiscovery setup step so MQTT defaults failing do not break onboarding

## Testing
- python -m compileall d2ha

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227cd47cd0832d89f81e9a55f05599)