### PR TITLE
Fix autodiscovery defaults and security toggle state

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -388,13 +388,15 @@ def apply_autodiscovery_default_choice(enable_all: bool) -> None:
     containers_info = docker_service.collect_containers_info_for_updates()
     containers_info = [c for c in containers_info if not mqtt_manager.is_self_container(c)]
     stable_ids = []
+    actions_pref = {
+        action: enable_all for action in AutodiscoveryPreferences.AVAILABLE_ACTIONS
+    }
     for container in containers_info:
         stable_id = container.get("stable_id")
         if not stable_id:
             continue
-        pref = autodiscovery_preferences.get_with_defaults(stable_id)
         autodiscovery_preferences.set_preferences(
-            stable_id, enable_all, pref.get("actions", {})
+            stable_id, enable_all, actions_pref
         )
         stable_ids.append(stable_id)
 

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -148,7 +148,7 @@
   </style>
   {% include 'partials/notifications_styles.html' %}
 </head>
-<body>
+<body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
       <h1>D2HA <span class="brand-pill">Webserver</span></h1>


### PR DESCRIPTION
## Summary
- ensure the onboarding choice to disable MQTT autodiscovery also disables all action entities by default
- align the security page safe mode toggle with the configured state via body data attributes

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227ea4ee54832d8cdf7388c5189d25)