### PR TITLE
Center header branding

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -19,8 +19,8 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.1rem; letter-spacing:0.1em; text-transform:uppercase; }
+    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
+    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
     .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
@@ -84,7 +84,7 @@
 <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
-      <h1>D2HA <span class="brand-pill">Autodiscovery</span></h1>
+      <h1>D2HA</h1>
       {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -19,8 +19,8 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.1rem; letter-spacing:0.1em; text-transform:uppercase; }
+    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
+    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
     .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
@@ -150,7 +150,7 @@
 <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
-      <h1>D2HA <span class="brand-pill">Container</span></h1>
+      <h1>D2HA</h1>
       {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -35,8 +35,8 @@
       z-index: 10;
       box-shadow: var(--shadow);
     }
-    .brand-line { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.1rem; letter-spacing:0.1em; text-transform:uppercase; }
+    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
+    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
     .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
@@ -85,7 +85,7 @@
 <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
-      <h1>D2HA <span class="brand-pill">Eventi</span></h1>
+      <h1>D2HA</h1>
       {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -36,20 +36,19 @@
       box-shadow: var(--shadow);
     }
     .brand-line {
+      position: relative;
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
       gap: 12px;
       flex-wrap: wrap;
     }
     .brand-line h1 {
       margin: 0;
-      font-size: 1.1rem;
-      letter-spacing: 0.1em;
+      font-size: 1.35rem;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
-      display: flex;
-      align-items: center;
-      gap: 8px;
+      text-align: center;
     }
     .brand-pill {
       padding: 4px 10px;
@@ -368,7 +367,7 @@
   <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
     <header>
       <div class="brand-line">
-        <h1>D2HA <span class="brand-pill">Webserver</span></h1>
+        <h1>D2HA</h1>
         {% include 'partials/notifications_panel.html' %}
       </div>
       <nav>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -19,8 +19,8 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.1rem; letter-spacing:0.1em; text-transform:uppercase; }
+    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
+    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
     .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
@@ -60,7 +60,7 @@
 <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
-      <h1>D2HA <span class="brand-pill">Immagini</span></h1>
+      <h1>D2HA</h1>
       {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -1,7 +1,9 @@
 <style>
   .header-actions {
-    position: relative;
-    margin-left: auto;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
     display: flex;
     align-items: center;
     gap: 10px;

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -37,20 +37,19 @@
       box-shadow: var(--shadow);
     }
     .brand-line {
+      position: relative;
       display: flex;
       align-items: center;
-      justify-content: space-between;
+      justify-content: center;
       gap: 12px;
       flex-wrap: wrap;
     }
     .brand-line h1 {
       margin: 0;
-      font-size: 1.1rem;
-      letter-spacing: 0.1em;
+      font-size: 1.35rem;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
-      display: flex;
-      align-items: center;
-      gap: 8px;
+      text-align: center;
     }
     .brand-pill {
       padding: 4px 10px;
@@ -151,7 +150,7 @@
 <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
-      <h1>D2HA <span class="brand-pill">Webserver</span></h1>
+      <h1>D2HA</h1>
       {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -19,8 +19,8 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.1rem; letter-spacing:0.1em; text-transform:uppercase; }
+    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
+    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
     .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
@@ -100,7 +100,7 @@
 <body data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
     <div class="brand-line">
-      <h1>D2HA <span class="brand-pill">Aggiornamenti</span></h1>
+      <h1>D2HA</h1>
       {% include 'partials/notifications_panel.html' %}
     </div>
     <nav>


### PR DESCRIPTION
## Summary
- center the header brand label and enlarge the D2HA title
- remove page-specific pills next to the main D2HA heading across views
- reposition header action controls to align with the centered brand

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922828468b8832db300af2986df9cc8)