### PR TITLE
Update header backend status indicator

### DIFF
--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -1,6 +1,11 @@
 <div class="header-actions">
   <div id="backend-status-indicator" class="backend-status backend-status-ok" title="Stato backend" aria-label="Stato backend">
-    <span class="backend-status-icon" aria-hidden="true">📡</span>
+    <svg class="backend-status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+      <path d="M3 10.5c5.5-5.5 12.5-5.5 18 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M6.5 14c3.25-3.25 7.75-3.25 11 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      <path d="M10 17.5c1.1-1.1 2.9-1.1 4 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+      <circle cx="12" cy="20" r="1.25" fill="currentColor" />
+    </svg>
   </div>
   <div class="header-clock" id="header-clock" aria-label="Orologio"></div>
   <div class="notif-area">

--- a/d2ha/templates/partials/notifications_script.html
+++ b/d2ha/templates/partials/notifications_script.html
@@ -173,6 +173,7 @@
     async function pingBackend() {
       const start = performance.now();
       let durationMs = 0;
+      backendStatusEl?.classList.add('backend-status-updating');
       try {
         const res = await fetch('/api/overview', { cache: 'no-store' });
         durationMs = performance.now() - start;
@@ -186,6 +187,8 @@
         console.error('Backend healthcheck failed', err);
         consecutiveErrors += 1;
         updateBackendStatus(durationMs);
+      } finally {
+        backendStatusEl?.classList.remove('backend-status-updating');
       }
     }
 

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -21,14 +21,23 @@
   .backend-status-ok { color: #4caf50; }
   .backend-status-degraded { color: #ff9800; }
   .backend-status-down { color: #f44336; }
+  .backend-status-updating {
+    color: #31c4ff;
+    animation: backend-status-pulse 1s ease-in-out infinite;
+  }
   .backend-status-icon {
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-size: 1rem;
     line-height: 1;
+  }
+  .backend-status-icon path { stroke: currentColor; }
+  .backend-status-icon circle { fill: currentColor; }
+  @keyframes backend-status-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.4; }
   }
   .header-clock {
     font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;


### PR DESCRIPTION
## Summary
- replace the header backend indicator icon with a Wi-Fi glyph
- add color-coded styling and pulsing animation for the indicator
- pulse the status icon during backend refresh operations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922875365e4832d810944b0522c14d3)