### PR TITLE
Move header clock and security access into dropdown

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -94,7 +94,6 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
-      <a href="{{ url_for('security_settings') }}" class="tab {{ 'active' if active_page == 'security' else '' }}">Sicurezza</a>
       <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -160,7 +160,6 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
-      <a href="{{ url_for('security_settings') }}" class="tab {{ 'active' if active_page == 'security' else '' }}">Sicurezza</a>
       <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -95,7 +95,6 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
-      <a href="{{ url_for('security_settings') }}" class="tab {{ 'active' if active_page == 'security' else '' }}">Sicurezza</a>
       <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -377,7 +377,6 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
-      <a href="{{ url_for('security_settings') }}" class="tab {{ 'active' if active_page == 'security' else '' }}">Sicurezza</a>
       <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -70,7 +70,6 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
-      <a href="{{ url_for('security_settings') }}" class="tab {{ 'active' if active_page == 'security' else '' }}">Sicurezza</a>
       <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>

--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -1,4 +1,8 @@
-<div class="header-actions">
+<div class="header-actions header-actions-left">
+  <div class="header-clock" id="header-clock" aria-label="Orologio"></div>
+</div>
+
+<div class="header-actions header-actions-right">
   <div id="backend-status-indicator" class="backend-status backend-status-ok" title="Stato backend" aria-label="Stato backend">
     <svg class="backend-status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
       <path d="M3 10.5c5.5-5.5 12.5-5.5 18 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
@@ -7,7 +11,6 @@
       <circle cx="12" cy="20" r="1.25" fill="currentColor" />
     </svg>
   </div>
-  <div class="header-clock" id="header-clock" aria-label="Orologio"></div>
   <div class="notif-area">
     <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
       <span class="notif-icon" aria-hidden="true">🔔</span>
@@ -41,6 +44,13 @@
         <div class="settings-row">
           <span>Uptime</span>
           <strong>{{ system_info.uptime }}</strong>
+        </div>
+        <div class="settings-row">
+          <div>
+            <span>Sicurezza</span>
+            <p class="settings-hint">Gestisci autenticazione e modalità sicura.</p>
+          </div>
+          <a class="settings-link" href="{{ url_for('security_settings') }}">Apri</a>
         </div>
         <div class="settings-row settings-row-toggle">
           <div>

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -1,13 +1,16 @@
 <style>
   .header-actions {
     position: absolute;
-    right: 0;
     top: 50%;
     transform: translateY(-50%);
     display: flex;
     align-items: center;
     gap: 10px;
   }
+
+  .header-actions-right { right: 0; }
+
+  .header-actions-left { left: 0; }
   .backend-status {
     display: inline-flex;
     align-items: center;
@@ -242,6 +245,20 @@
   .settings-row strong { color: var(--text); }
   .settings-safe { border-top: 1px solid var(--border); padding-top: 8px; }
   .settings-hint { margin: 4px 0 0; color: var(--muted); font-size: 0.85rem; }
+  .settings-link {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 8px 12px;
+    background: rgba(255,255,255,0.05);
+    color: var(--text);
+    font-weight: 700;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    text-decoration: none;
+    box-shadow: var(--shadow);
+  }
+  .settings-link:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
   .switch { position: relative; width: 46px; height: 26px; }
   .switch input {
     opacity: 0;

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -160,7 +160,6 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
-      <a href="{{ url_for('security_settings') }}" class="tab {{ 'active' if active_page == 'security' else '' }}">Sicurezza</a>
       <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -110,7 +110,6 @@
       <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">Aggiornamenti</a>
       <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">Eventi</a>
       <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">Autodiscovery</a>
-      <a href="{{ url_for('security_settings') }}" class="tab {{ 'active' if active_page == 'security' else '' }}">Sicurezza</a>
       <a href="{{ url_for('logout') }}" class="tab logout-link">Logout</a>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- reposition the header clock on the left side of the header
- hide the security page from the navigation tabs and link it through the settings dropdown
- add styling for the new settings dropdown entry

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228aab3ec0832da3fe5634dc52f1a5)