### PR TITLE
Add security icon to security settings shortcut

### DIFF
--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -50,7 +50,12 @@
             <span>Sicurezza</span>
             <p class="settings-hint">Gestisci autenticazione e modalità sicura.</p>
           </div>
-          <a class="settings-link" href="{{ url_for('security_settings') }}">Apri</a>
+          <a class="settings-link settings-link-icon" href="{{ url_for('security_settings') }}" aria-label="Apri impostazioni di sicurezza">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M12 3l7 4v5c0 4.97-3.58 9.36-7 9.97-3.42-.61-7-5-7-9.97V7l7-4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+              <path d="M9.5 12.5l2 2 3-3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </a>
         </div>
         <div class="settings-row settings-row-toggle">
           <div>

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -258,6 +258,16 @@
     text-decoration: none;
     box-shadow: var(--shadow);
   }
+  .settings-link-icon {
+    padding: 8px;
+    width: 38px;
+    height: 38px;
+    justify-content: center;
+  }
+  .settings-link-icon svg {
+    width: 18px;
+    height: 18px;
+  }
   .settings-link:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
   .switch { position: relative; width: 46px; height: 26px; }
   .switch input {


### PR DESCRIPTION
## Summary
- replace the security settings button label with a security-themed icon
- add dedicated styling for the icon link in the header settings panel

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228dc36080832d82254c41d47bfd8e)