### PR TITLE
Improve light theme contrast and translations

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -317,7 +317,7 @@ def setup_account():
             config["password_hash"] = generate_password_hash(new_password)
             save_auth_config(config)
             session["user"] = config["username"]
-            flash("Account updated. Let's finish setting up security.", "success")
+            flash("Account aggiornato. Completiamo la configurazione della sicurezza.", "success")
             return redirect(url_for("setup_2fa"))
 
     return render_template(
@@ -349,7 +349,7 @@ def setup_2fa():
             save_auth_config(config)
             session.pop("pending_totp_secret", None)
             flash(
-                "2FA is currently disabled. You can enable it later in Security Settings.",
+                "L'autenticazione a due fattori è disattivata. Potrai abilitarla più tardi nelle Impostazioni di sicurezza.",
                 "info",
             )
             return redirect(url_for("setup_modes"))

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -5,40 +5,61 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Autodiscovery</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
+    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
     .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
     .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
+    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
-    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
+    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .meta { color: var(--muted); font-size:0.9rem; }
@@ -50,7 +71,7 @@
     .stack-title { font-weight:700; font-size:1rem; letter-spacing:0.08em; display:flex; align-items:center; gap:8px; text-transform: uppercase; }
     .stack-chip { padding:4px 10px; border-radius:999px; background: rgba(255,255,255,0.05); color: var(--muted); font-size:0.8rem; }
     .stack-toggle-btn { border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); border-radius:8px; padding:4px 8px; cursor:pointer; display:inline-flex; align-items:center; gap:6px; }
-    .stack-toggle-btn:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
+    .stack-toggle-btn:hover { border-color: var(--accent-border); color: var(--accent); }
     .stack-toggle-btn .chevron { display:inline-block; width:10px; text-align:center; }
     .stack-content { border-top:1px solid var(--border); }
     .stack-content.collapsed { display:none; }
@@ -70,10 +91,10 @@
     .name { font-weight:700; }
     .muted { color: var(--muted); font-size:0.85rem; }
     .actions-bar { display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; }
-    .btn-primary { background: linear-gradient(135deg, #1b87f1, #31c4ff); border:none; color:#0b111c; border-radius:12px; padding:10px 16px; font-weight:800; cursor:pointer; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .btn-primary { background: var(--accent-gradient); border:none; color:#0b111c; border-radius:12px; padding:10px 16px; font-weight:800; cursor:pointer; box-shadow:0 6px 18px var(--accent-glow); }
     .btn-secondary { background: rgba(255,255,255,0.06); border:1px solid var(--border); color: var(--text); border-radius:12px; padding:8px 12px; font-weight:700; cursor:pointer; transition: all 0.15s ease; }
     .btn-secondary:hover { border-color: rgba(49,196,255,0.5); color: var(--accent); }
-    .note { background: rgba(49,196,255,0.08); border:1px solid rgba(49,196,255,0.25); padding:10px 12px; border-radius:12px; font-size:0.9rem; }
+    .note { background: var(--accent-surface); border:1px solid var(--accent-glow-soft); padding:10px 12px; border-radius:12px; font-size:0.9rem; }
     .safe-locked .checkbox-item { opacity: 0.45; pointer-events: none; }
     .safe-locked .checkbox input { pointer-events: none; }
     .safe-locked .btn-secondary { opacity: 0.45; cursor: not-allowed; pointer-events: none; }
@@ -85,7 +106,7 @@
     .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
+    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 960px) {
       table { min-width: 720px; }
       th, td { font-size:0.82rem; }

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -5,50 +5,71 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Container</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
+    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
     .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
     .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
+    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
-    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
+    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 16px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .stack-card { display:flex; flex-direction:column; gap:12px; }
-    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:2px; padding:12px 14px; border:1px solid var(--border); border-radius:12px; background: linear-gradient(135deg, #141927, #0f131d); box-shadow: var(--shadow); }
+    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:2px; padding:12px 14px; border:1px solid var(--border); border-radius:12px; background: var(--stack-header-bg); box-shadow: var(--shadow); }
     .stack-toggle { margin-bottom:0; cursor:pointer; }
     .stack-title { font-size:1rem; font-weight:800; display:flex; align-items:center; gap:10px; letter-spacing:0.02em; }
     .stack-name { text-transform: uppercase; letter-spacing:0.08em; }
     .stack-chip { padding:4px 10px; border-radius:999px; background: rgba(255,255,255,0.05); color: var(--muted); font-size:0.85rem; font-weight:700; }
     .stack-toggle-btn { border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); border-radius:10px; padding:6px 10px; cursor:pointer; display:inline-flex; align-items:center; gap:6px; min-height:32px; }
-    .stack-toggle-btn:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
+    .stack-toggle-btn:hover { border-color: var(--accent-border); color: var(--accent); }
     .stack-toggle-btn .chevron { display:inline-block; width:10px; text-align:center; }
     .stack-content.collapsed { display:none; }
     table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
@@ -71,9 +92,9 @@
     .col-networks, .col-ports { width: 170px; }
     .col-actions { width: 200px; }
     .btn { border:1px solid transparent; border-radius:999px; padding:8px 14px; font-size:0.82rem; cursor:pointer; background:#262c3c; color: var(--text); transition: background 0.15s ease, transform 0.05s ease, box-shadow 0.15s ease, border-color 0.15s ease; letter-spacing:0.01em; }
-    .btn:hover { background:#31394e; transform: translateY(-1px); border-color: rgba(49,196,255,0.45); box-shadow:0 6px 18px rgba(49,196,255,0.25); }
-    .btn-strong { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0b111c; box-shadow:0 8px 18px rgba(49,196,255,0.35); font-weight:800; }
-    .btn-ghost { background: rgba(49,196,255,0.12); color: var(--accent); border-color: rgba(49,196,255,0.45); font-weight:800; }
+    .btn:hover { background:#31394e; transform: translateY(-1px); border-color: var(--accent-border); box-shadow:0 6px 18px var(--accent-glow-soft); }
+    .btn-strong { background: var(--accent-gradient); color:#0b111c; box-shadow:0 8px 18px var(--accent-glow); font-weight:800; }
+    .btn-ghost { background: var(--accent-surface); color: var(--accent); border-color: var(--accent-border); font-weight:800; }
     .btn-ghost:hover { background: rgba(49,196,255,0.18); }
     .btn-play { background:#2ecc71; color:#07130c; }
     .btn-stop { background:#e74c3c; }
@@ -86,7 +107,7 @@
     .checkbox { position:relative; display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; }
     .checkbox input { position:absolute; inset:0; margin:0; opacity:0; cursor:pointer; z-index:2; }
     .checkmark { width:100%; height:100%; border-radius:6px; border:1px solid var(--border); display:inline-flex; align-items:center; justify-content:center; background: rgba(255,255,255,0.04); transition: all 0.15s ease; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04); }
-    .checkbox input:checked + .checkmark { background: linear-gradient(135deg, #1b87f1, #31c4ff); border-color: rgba(49,196,255,0.8); box-shadow: 0 0 0 4px rgba(49,196,255,0.18); }
+    .checkbox input:checked + .checkmark { background: var(--accent-gradient); border-color: rgba(49,196,255,0.8); box-shadow: 0 0 0 4px rgba(49,196,255,0.18); }
     .checkbox input:checked + .checkmark::after { content:'✓'; color:#0b111c; font-weight:900; font-size:0.85rem; }
     .bulk-bar { position:fixed; left:0; right:0; bottom:0; background: rgba(21,25,36,0.95); border-top:1px solid var(--border); padding:12px 18px; display:none; align-items:center; justify-content:space-between; gap:12px; box-shadow: 0 -8px 20px rgba(0,0,0,0.35); z-index:30; }
     .bulk-bar.visible { display:flex; }
@@ -108,7 +129,7 @@
     .field h4 { margin:0 0 6px 0; color:var(--muted); font-size:0.85rem; letter-spacing:0.01em; }
     .kv { display:flex; justify-content:space-between; gap:10px; padding:6px 0; border-bottom:1px solid var(--border); font-size:0.85rem; }
     .kv:last-child { border-bottom:none; }
-    .badge { display:inline-flex; align-items:center; padding:4px 8px; border-radius:999px; background: rgba(49,196,255,0.12); color: var(--accent); font-size:0.8rem; }
+    .badge { display:inline-flex; align-items:center; padding:4px 8px; border-radius:999px; background: var(--accent-surface); color: var(--accent); font-size:0.8rem; }
     .muted { color: var(--muted); font-size:0.85rem; }
     .stats-row { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:12px; }
     .stat-box { background: var(--panel); border:1px solid var(--border); border-radius:12px; padding:10px 12px; display:flex; flex-direction:column; gap:6px; }
@@ -118,13 +139,13 @@
     .logs-area .log-line { padding:4px 8px; border-left:3px solid transparent; margin-bottom:2px; border-radius:8px; display:flex; gap:8px; align-items:flex-start; }
     .logs-area .log-line:last-child { margin-bottom:0; }
     .logs-area .log-bullet { opacity:0.4; }
-    .logs-area .log-info { border-color:#31c4ff; background:rgba(49,196,255,0.06); }
+    .logs-area .log-info { border-color: var(--accent); background:rgba(49,196,255,0.06); }
     .logs-area .log-warn { border-color:#ffd54f; background:rgba(255,213,79,0.07); }
     .logs-area .log-error { border-color:#ff8a7a; background:rgba(255,138,122,0.08); }
     .logs-area .log-debug { border-color:#9aa7bd; background:rgba(154,167,189,0.06); color:#c5cee0; }
     .logs-area .log-other { border-color:rgba(255,255,255,0.08); }
     .controls { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
-    .select, .input { background: #0f141f; color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
+    .select, .input { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
     .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background:#1d2535; color: var(--text); cursor:pointer; }
     .chip { background: rgba(255,255,255,0.05); border:1px solid var(--border); padding:4px 8px; border-radius:8px; font-size:0.8rem; }
     .small { font-size:0.8rem; color:var(--muted); }
@@ -139,8 +160,8 @@
     .toast.visible { opacity:1; transform: translateY(0); }
     .toast-message { font-weight:700; font-size:0.9rem; }
     .toast-actions { display:flex; gap:8px; }
-    .toast-actions button { border:none; border-radius:999px; padding:6px 10px; background: rgba(49,196,255,0.12); color: var(--text); cursor:pointer; font-weight:700; }
-    .toast-info { border-color: rgba(49,196,255,0.25); }
+    .toast-actions button { border:none; border-radius:999px; padding:6px 10px; background: var(--accent-surface); color: var(--text); cursor:pointer; font-weight:700; }
+    .toast-info { border-color: var(--accent-glow-soft); }
     .toast-success { border-color: rgba(124,255,195,0.25); }
     .toast-error { border-color: rgba(255,138,122,0.25); }
     .toast-warning { border-color: rgba(255,213,79,0.35); }
@@ -148,7 +169,7 @@
     .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
+    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -5,28 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Eventi</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -39,7 +59,7 @@
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: linear-gradient(90deg, #0d111c, #12182a);
+      background: var(--header-bg);
       border-bottom: 1px solid var(--border);
       padding: 16px 22px 12px;
       position: sticky;
@@ -49,17 +69,17 @@
     }
     .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
     .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
+    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
-    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
+    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .filters { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
-    .select, .input { background: #0f141f; color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
-    .btn { border:none; border-radius:10px; padding:9px 14px; font-weight:700; cursor:pointer; background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
+    .select, .input { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
+    .btn { border:none; border-radius:10px; padding:9px 14px; font-weight:700; cursor:pointer; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
     .table-card { padding:0; overflow:hidden; }
     .table-head { display:flex; justify-content:space-between; align-items:center; padding:14px 16px; border-bottom:1px solid var(--border); background: rgba(255,255,255,0.02); flex-wrap:wrap; gap:10px; }
     table { width:100%; border-collapse: collapse; }
@@ -69,7 +89,7 @@
     tr:hover { background: rgba(255,255,255,0.03); }
     .sev-pill { display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; font-weight:700; text-transform: uppercase; font-size:0.75rem; }
     .sev-dot { width:10px; height:10px; border-radius:50%; display:inline-block; }
-    .sev-info { background: rgba(49,196,255,0.12); color: #31c4ff; }
+    .sev-info { background: var(--accent-surface); color: #31c4ff; }
     .sev-info .sev-dot { background:#31c4ff; }
     .sev-warning { background: rgba(255,213,79,0.16); color: #ffd54f; }
     .sev-warning .sev-dot { background:#ffd54f; }
@@ -83,7 +103,7 @@
     .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
+    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media (max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -5,28 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Home</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -39,7 +59,7 @@
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: linear-gradient(90deg, #0d111c, #12182a);
+      background: var(--header-bg);
       border-bottom: 1px solid var(--border);
       padding: 16px 22px 12px;
       position: sticky;
@@ -66,7 +86,7 @@
       padding: 4px 10px;
       border-radius: 999px;
       border: 1px solid var(--border);
-      background: rgba(49,196,255,0.1);
+      background: var(--accent-surface);
       color: var(--accent);
       font-size: 0.8rem;
       letter-spacing: 0.04em;
@@ -88,15 +108,15 @@
     }
     .tab:hover { color: var(--text); border-color: var(--border); }
     .tab.active {
-      background: linear-gradient(135deg, #1b87f1, #31c4ff);
+      background: var(--accent-gradient);
       color: #0c121e;
-      box-shadow: 0 6px 18px rgba(49,196,255,0.35);
+      box-shadow: 0 6px 18px var(--accent-glow);
     }
     .logout-link {
       margin-left: auto;
-      background: linear-gradient(135deg, #7cffc3, #31c4ff);
+      background: var(--accent-gradient);
       color: #0c121e;
-      box-shadow: 0 6px 18px rgba(124,255,195,0.25);
+      box-shadow: 0 6px 18px var(--accent-glow-soft);
     }
     .layout {
       display: grid;
@@ -127,7 +147,7 @@
       padding: 10px 12px;
       transition: border-color 0.15s ease;
     }
-    details[open] { border-color: rgba(49,196,255,0.4); }
+    details[open] { border-color: var(--accent-border); }
     summary {
       cursor: pointer;
       list-style: none;
@@ -188,8 +208,8 @@
     }
     .log-link:hover {
       color: var(--accent);
-      border-color: rgba(49,196,255,0.4);
-      background: rgba(49,196,255,0.08);
+      border-color: var(--accent-border);
+      background: var(--accent-surface);
     }
     .log-link svg { width: 16px; height: 16px; fill: currentColor; }
     .modal-backdrop { position: fixed; inset:0; background: rgba(0,0,0,0.65); display:none; align-items:center; justify-content:center; z-index: 50; padding:20px; }
@@ -201,13 +221,13 @@
     .modal-body { padding:16px; overflow-y:auto; flex:1; display:flex; flex-direction:column; gap:12px; min-height:0; }
     .inline-controls { display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
     .inline-controls .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.05); color: var(--text); cursor:pointer; transition: all 0.15s ease; }
-    .inline-controls .inline-btn:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
-    .select { background: #0f141f; color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
+    .inline-controls .inline-btn:hover { border-color: var(--accent-border); color: var(--accent); }
+    .select { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
     .logs-area { background: #0d1018; border:1px solid var(--border); border-radius:12px; padding:10px; font-family:"JetBrains Mono", monospace; font-size:0.85rem; max-height:100%; overflow:auto; white-space:pre-wrap; }
     .logs-area .log-line { padding:4px 8px; border-left:3px solid transparent; margin-bottom:2px; border-radius:8px; display:flex; gap:8px; align-items:flex-start; }
     .logs-area .log-line:last-child { margin-bottom:0; }
     .logs-area .log-bullet { opacity:0.4; }
-    .logs-area .log-info { border-color:#31c4ff; background:rgba(49,196,255,0.06); }
+    .logs-area .log-info { border-color: var(--accent); background:rgba(49,196,255,0.06); }
     .logs-area .log-warn { border-color:#ffd54f; background:rgba(255,213,79,0.07); }
     .logs-area .log-error { border-color:#ff8a7a; background:rgba(255,138,122,0.08); }
     .logs-area .log-debug { border-color:#9aa7bd; background:rgba(154,167,189,0.06); color:#c5cee0; }
@@ -284,7 +304,7 @@
     .bar span {
       display: block;
       height: 100%;
-      background: linear-gradient(90deg, #31c4ff, #7cffc3);
+      background: linear-gradient(90deg, var(--accent), var(--accent-2));
       width: 0;
       transition: width 0.4s ease;
     }
@@ -368,7 +388,7 @@
     }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
+    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media (max-width: 960px) {
       .layout { grid-template-columns: 1fr; }
     }

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -5,40 +5,61 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Immagini</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
+    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
     .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
     .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
+    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
-    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
+    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; }
@@ -58,7 +79,7 @@
     .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
+    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }

--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -5,27 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>{{ t("login.title") }}</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
+
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -43,7 +64,7 @@
     }
     .card {
       width: min(460px, 100%);
-      background: linear-gradient(160deg, rgba(49,196,255,0.08), rgba(124,255,195,0.06)), var(--panel);
+      background: linear-gradient(160deg, var(--accent-surface), rgba(124,255,195,0.06)), var(--panel);
       border: 1px solid var(--border);
       border-radius: 16px;
       padding: 20px 22px;
@@ -67,11 +88,11 @@
       padding: 12px;
       border: none;
       border-radius: 12px;
-      background: linear-gradient(135deg, #1b87f1, #31c4ff);
+      background: var(--accent-gradient);
       color: #0c121e;
       font-weight: 800;
       cursor: pointer;
-      box-shadow: 0 8px 18px rgba(49,196,255,0.35);
+      box-shadow: 0 8px 18px var(--accent-glow);
     }
     .btn:hover { filter: brightness(1.05); }
     .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -47,7 +47,7 @@
     padding: 10px 12px;
     border-radius: 10px;
     border: 1px solid var(--border);
-    background: rgba(255,255,255,0.04);
+    background: var(--control-surface);
     color: var(--text);
     letter-spacing: 0.08em;
     box-shadow: var(--shadow);
@@ -63,7 +63,7 @@
   .notif-toggle,
   .settings-toggle {
     position: relative;
-    background: rgba(255,255,255,0.05);
+    background: var(--control-surface);
     border: 1px solid var(--border);
     color: var(--text);
     border-radius: 10px;
@@ -150,12 +150,12 @@
     transition: border-color 0.15s ease, background 0.15s ease, transform 0.05s ease;
   }
   .backend-modal-btn.primary {
-    background: linear-gradient(135deg, #1b87f1, #31c4ff);
+    background: var(--accent-gradient);
     color: #0c121e;
-    border-color: rgba(49,196,255,0.55);
-    box-shadow: 0 6px 18px rgba(49,196,255,0.35);
+    border-color: var(--accent-border-strong);
+    box-shadow: 0 6px 18px var(--accent-glow);
   }
-  .backend-modal-btn:hover { transform: translateY(-1px); border-color: rgba(49,196,255,0.4); }
+  .backend-modal-btn:hover { transform: translateY(-1px); border-color: var(--accent-border); }
   .notif-panel {
     position: absolute;
     right: 0;
@@ -268,7 +268,7 @@
     width: 18px;
     height: 18px;
   }
-  .settings-link:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
+  .settings-link:hover { border-color: var(--accent-border); color: var(--accent); }
   .switch { position: relative; width: 46px; height: 26px; }
   .switch input {
     opacity: 0;
@@ -302,8 +302,8 @@
     box-shadow: 0 4px 12px rgba(0,0,0,0.25);
   }
   .switch input:checked + .slider {
-    background: linear-gradient(135deg, #1b87f1, #31c4ff);
-    border-color: rgba(49,196,255,0.55);
+    background: var(--accent-gradient);
+    border-color: var(--accent-border-strong);
   }
   .switch input:checked + .slider::before { transform: translateX(18px); }
 
@@ -356,5 +356,5 @@
     color: var(--text);
   }
 
-  .btn-secondary:hover { border-color: rgba(49,196,255,0.45); }
+  .btn-secondary:hover { border-color: var(--accent-border); }
 </style>

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -5,28 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Sicurezza</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -40,7 +60,7 @@
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: linear-gradient(90deg, #0d111c, #12182a);
+      background: var(--header-bg);
       border-bottom: 1px solid var(--border);
       padding: 16px 22px 12px;
       position: sticky;
@@ -67,7 +87,7 @@
       padding: 4px 10px;
       border-radius: 999px;
       border: 1px solid var(--border);
-      background: rgba(49,196,255,0.1);
+      background: var(--accent-surface);
       color: var(--accent);
       font-size: 0.8rem;
       letter-spacing: 0.04em;
@@ -89,15 +109,15 @@
     }
     .tab:hover { color: var(--text); border-color: var(--border); }
     .tab.active {
-      background: linear-gradient(135deg, #1b87f1, #31c4ff);
+      background: var(--accent-gradient);
       color: #0c121e;
-      box-shadow: 0 6px 18px rgba(49,196,255,0.35);
+      box-shadow: 0 6px 18px var(--accent-glow);
     }
     .logout-link {
       margin-left: auto;
-      background: linear-gradient(135deg, #7cffc3, #31c4ff);
+      background: var(--accent-gradient);
       color: #0c121e;
-      box-shadow: 0 6px 18px rgba(124,255,195,0.25);
+      box-shadow: 0 6px 18px var(--accent-glow-soft);
     }
     .container {
       max-width: 1100px;
@@ -128,7 +148,7 @@
       background: var(--panel-2);
       color: var(--text);
     }
-    input:focus { outline: 2px solid rgba(49,196,255,0.4); }
+    input:focus { outline: 2px solid var(--accent-border); }
     .actions { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
     button {
       padding: 10px 16px;
@@ -136,9 +156,9 @@
       border: none;
       cursor: pointer;
       font-weight: 700;
-      background: linear-gradient(135deg, #1b87f1, #31c4ff);
+      background: var(--accent-gradient);
       color: #0c121e;
-      box-shadow: 0 6px 18px rgba(49,196,255,0.35);
+      box-shadow: 0 6px 18px var(--accent-glow);
     }
     button.secondary { background: rgba(255,255,255,0.06); color: var(--text); border: 1px solid var(--border); box-shadow: none; }
     .status { padding: 8px 12px; border-radius: 10px; border: 1px solid var(--border); display: inline-flex; gap: 8px; align-items: center; }
@@ -149,9 +169,9 @@
     .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
+    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     .flash.warning { border-color: rgba(255,192,99,0.5); background: rgba(255,192,99,0.08); }
-    .pending-box { margin-top: 12px; padding: 12px; border-radius: 12px; border: 1px dashed rgba(49,196,255,0.4); background: rgba(49,196,255,0.06); }
+    .pending-box { margin-top: 12px; padding: 12px; border-radius: 12px; border: 1px dashed var(--accent-border); background: var(--accent-surface); }
     .qr-box { display: grid; gap: 10px; align-items: center; grid-template-columns: auto 1fr; }
     .qr-box img { background: white; padding: 8px; border-radius: 10px; }
     .secret-chip { padding: 6px 10px; border-radius: 10px; background: rgba(255,255,255,0.06); border: 1px solid var(--border); display: inline-block; }

--- a/d2ha/templates/setup_2fa.html
+++ b/d2ha/templates/setup_2fa.html
@@ -5,28 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Configura 2FA</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -44,7 +64,7 @@
     }
     .card {
       width: min(520px, 100%);
-      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
       border: 1px solid var(--border);
       border-radius: 16px;
       padding: 20px 22px;
@@ -52,11 +72,11 @@
     }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
     .secret-box { background: var(--panel-2); border:1px solid var(--border); border-radius: 12px; padding: 12px; font-family: "JetBrains Mono", monospace; margin: 8px 0; }
     .actions { display: flex; gap: 12px; flex-wrap: wrap; }
     .btn { padding: 12px 16px; border-radius: 12px; border: none; font-weight: 800; cursor: pointer; }
-    .btn-primary { background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; box-shadow: 0 8px 18px rgba(49,196,255,0.35); }
+    .btn-primary { background: var(--accent-gradient); color: #0c121e; box-shadow: 0 8px 18px var(--accent-glow); }
     .btn-secondary { background: rgba(255,255,255,0.06); color: var(--text); border:1px solid var(--border); }
     input[type="text"] { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
     .flash-container { margin: 12px 0; display: flex; flex-direction: column; gap: 8px; }

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -5,28 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Primo accesso</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -44,7 +64,7 @@
     }
     .card {
       width: min(520px, 100%);
-      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
       border: 1px solid var(--border);
       border-radius: 16px;
       padding: 20px 22px;
@@ -52,11 +72,11 @@
     }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
     form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
     label { font-weight: 700; color: var(--text); font-size: 0.9rem; }
     input { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
-    .btn { margin-top: 6px; padding: 12px; border: none; border-radius: 12px; background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: 0 8px 18px rgba(49,196,255,0.35); }
+    .btn { margin-top: 6px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: 0 8px 18px var(--accent-glow); }
     .btn:hover { filter: brightness(1.05); }
     .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
     .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }

--- a/d2ha/templates/setup_autodiscovery.html
+++ b/d2ha/templates/setup_autodiscovery.html
@@ -5,28 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Autodiscovery MQTT</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -44,7 +64,7 @@
     }
     .card {
       width: min(520px, 100%);
-      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
       border: 1px solid var(--border);
       border-radius: 16px;
       padding: 20px 22px;
@@ -52,11 +72,11 @@
     }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
     form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
     label { font-weight: 700; color: var(--text); font-size: 0.95rem; display:block; }
     input[type="radio"] { width: 18px; height: 18px; accent-color: var(--accent); }
-    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
+    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
     button:hover { filter: brightness(1.05); }
     .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
     .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
@@ -97,7 +117,6 @@
       <button type="submit" style="margin-top:16px;">Completa configurazione</button>
     </form>
 
-    <p class="hint" style="margin-top:12px;">Potrai sempre modificare queste scelte in seguito dalla pagina Autodiscovery.</p>
   </div>
 </body>
 </html>

--- a/d2ha/templates/setup_modes.html
+++ b/d2ha/templates/setup_modes.html
@@ -5,28 +5,48 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Modalità del sistema</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
       --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body {
@@ -44,7 +64,7 @@
     }
     .card {
       width: min(520px, 100%);
-      background: linear-gradient(180deg, rgba(49,196,255,0.08), rgba(124,255,195,0.04)), var(--panel);
+      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
       border: 1px solid var(--border);
       border-radius: 16px;
       padding: 20px 22px;
@@ -52,11 +72,11 @@
     }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: rgba(49,196,255,0.12); color: var(--accent); border:1px solid rgba(49,196,255,0.3); font-weight: 800; letter-spacing: 0.05em; }
+    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
     form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
     label { font-weight: 700; color: var(--text); font-size: 0.95rem; }
     input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); }
-    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: linear-gradient(135deg, #1b87f1, #31c4ff); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
+    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
     button:hover { filter: brightness(1.05); }
     .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
     .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -5,40 +5,61 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Aggiornamenti</title>
   <style>
-    :root {
+                :root {
       --bg: #0f1116;
       --panel: #151924;
       --panel-2: #1b2131;
       --accent: #31c4ff;
+      --accent-2: #7cffc3;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(49,196,255,0.35);
+      --accent-glow-soft: rgba(49,196,255,0.25);
+      --accent-border-strong: rgba(49,196,255,0.55);
+      --accent-border: rgba(49,196,255,0.45);
+      --accent-border-soft: rgba(49,196,255,0.3);
+      --accent-surface: rgba(49,196,255,0.08);
       --text: #e7ecf4;
       --muted: #9aa7bd;
       --border: rgba(255,255,255,0.08);
       --shadow: 0 10px 30px rgba(0,0,0,0.45);
+      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+      --control-surface: #0f141f;
     }
 
     body.theme-light {
-      --bg: #f8f8f8;
+      --bg: #fff7ed;
       --panel: #ffffff;
-      --panel-2: #f2f4f8;
-      --accent: #2563eb;
-      --accent-2: #16a34a;
-      --text: #111827;
+      --panel-2: #fff3df;
+      --accent: #f97316;
+      --accent-2: #fb923c;
+      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow-soft: rgba(249,115,22,0.18);
+      --accent-border-strong: rgba(249,115,22,0.55);
+      --accent-border: rgba(249,115,22,0.42);
+      --accent-border-soft: rgba(249,115,22,0.26);
+      --accent-surface: rgba(249,115,22,0.08);
+      --text: #1f2937;
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
+      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
+      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --control-surface: #fffaf3;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: linear-gradient(90deg, #0d111c, #12182a); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
+    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
     .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
     .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: rgba(49,196,255,0.1); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
+    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: linear-gradient(135deg, #1b87f1, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(49,196,255,0.35); }
-    .logout-link { margin-left:auto; background: linear-gradient(135deg, #7cffc3, #31c4ff); color:#0c121e; box-shadow:0 6px 18px rgba(124,255,195,0.25); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
+    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
@@ -74,13 +95,13 @@
     .performance-hint .hint-title { font-weight: 800; margin-bottom: 4px; display: block; }
     code { font-family: "JetBrains Mono", "Fira Code", Consolas, monospace; font-size: 0.75rem; }
     .stack-card { margin-bottom: 12px; display:flex; flex-direction:column; gap:10px; }
-    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 14px; border:1px solid var(--border); border-radius:12px; background: linear-gradient(135deg, #141927, #0f131d); cursor:pointer; box-shadow: var(--shadow); }
+    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:12px 14px; border:1px solid var(--border); border-radius:12px; background: var(--stack-header-bg); cursor:pointer; box-shadow: var(--shadow); }
     .stack-left { display:flex; align-items:center; gap:10px; min-width:0; }
     .stack-heading { display:flex; flex-direction:column; gap:4px; min-width:0; }
     .stack-title { font-weight:800; font-size:1rem; letter-spacing:0.08em; text-transform: uppercase; }
     .stack-chip { padding:4px 10px; border-radius:999px; background: rgba(255,255,255,0.06); color: var(--muted); font-size:0.85rem; font-weight:700; text-transform: uppercase; letter-spacing:0.05em; }
     .stack-toggle-btn { border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); border-radius:10px; padding:6px 10px; cursor:pointer; display:inline-flex; align-items:center; gap:6px; min-height:32px; }
-    .stack-toggle-btn:hover { border-color: rgba(49,196,255,0.45); color: var(--accent); }
+    .stack-toggle-btn:hover { border-color: var(--accent-border); color: var(--accent); }
     .chevron { transition: transform 0.2s ease; font-size: 0.95rem; color: var(--muted); display:inline-block; width:12px; text-align:center; }
     .collapsed .chevron { transform: rotate(-90deg); }
     .stack-body { margin-top: 10px; display:block; }
@@ -97,7 +118,7 @@
     .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: rgba(49,196,255,0.4); background: rgba(49,196,255,0.08); }
+    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 1100px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }


### PR DESCRIPTION
## Summary
- Localize onboarding flash messages and remove redundant autodiscovery hint during setup
- Refresh light theme with orange accents and higher contrast for headers, stacks, filters, and controls across the UI
- Ensure header clock and notification controls use the theme surfaces for better visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fee3bd8c832d89eea7eddee65de0)