### PR TITLE
Improve light theme readability across UI

### DIFF
--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -91,8 +91,8 @@
     .col-uptime, .col-cpu, .col-ram, .col-restart { width: 110px; }
     .col-networks, .col-ports { width: 170px; }
     .col-actions { width: 200px; }
-    .btn { border:1px solid transparent; border-radius:999px; padding:8px 14px; font-size:0.82rem; cursor:pointer; background:#262c3c; color: var(--text); transition: background 0.15s ease, transform 0.05s ease, box-shadow 0.15s ease, border-color 0.15s ease; letter-spacing:0.01em; }
-    .btn:hover { background:#31394e; transform: translateY(-1px); border-color: var(--accent-border); box-shadow:0 6px 18px var(--accent-glow-soft); }
+    .btn { border:1px solid var(--border); border-radius:999px; padding:8px 14px; font-size:0.82rem; cursor:pointer; background: var(--control-surface); color: var(--text); transition: background 0.15s ease, transform 0.05s ease, box-shadow 0.15s ease, border-color 0.15s ease; letter-spacing:0.01em; box-shadow: 0 6px 18px var(--shadow); }
+    .btn:hover { background: var(--accent-surface); transform: translateY(-1px); border-color: var(--accent-border); box-shadow:0 8px 20px var(--accent-glow-soft); color: var(--accent); }
     .btn-strong { background: var(--accent-gradient); color:#0b111c; box-shadow:0 8px 18px var(--accent-glow); font-weight:800; }
     .btn-ghost { background: var(--accent-surface); color: var(--accent); border-color: var(--accent-border); font-weight:800; }
     .btn-ghost:hover { background: rgba(49,196,255,0.18); }
@@ -109,14 +109,14 @@
     .checkmark { width:100%; height:100%; border-radius:6px; border:1px solid var(--border); display:inline-flex; align-items:center; justify-content:center; background: rgba(255,255,255,0.04); transition: all 0.15s ease; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04); }
     .checkbox input:checked + .checkmark { background: var(--accent-gradient); border-color: rgba(49,196,255,0.8); box-shadow: 0 0 0 4px rgba(49,196,255,0.18); }
     .checkbox input:checked + .checkmark::after { content:'✓'; color:#0b111c; font-weight:900; font-size:0.85rem; }
-    .bulk-bar { position:fixed; left:0; right:0; bottom:0; background: rgba(21,25,36,0.95); border-top:1px solid var(--border); padding:12px 18px; display:none; align-items:center; justify-content:space-between; gap:12px; box-shadow: 0 -8px 20px rgba(0,0,0,0.35); z-index:30; }
+    .bulk-bar { position:fixed; left:0; right:0; bottom:0; background: var(--panel); border-top:1px solid var(--border); padding:12px 18px; display:none; align-items:center; justify-content:space-between; gap:12px; box-shadow: 0 -8px 20px rgba(0,0,0,0.25); z-index:30; color: var(--text); }
     .bulk-bar.visible { display:flex; }
     .bulk-summary { color: var(--muted); font-weight:700; letter-spacing:0.02em; }
     .bulk-actions { display:flex; gap:8px; flex-wrap:wrap; }
     .modal-backdrop { position: fixed; inset:0; background: rgba(0,0,0,0.65); display:none; align-items:center; justify-content:center; z-index: 50; padding:20px; }
     .modal-backdrop.visible { display:flex; }
     .modal { background: var(--panel-2); border:1px solid var(--border); border-radius:16px; width:min(1100px, 100%); height:82vh; max-height:82vh; overflow:hidden; box-shadow: var(--shadow); display:flex; flex-direction:column; }
-    .modal-header { display:flex; align-items:center; justify-content:space-between; padding:16px 18px; border-bottom:1px solid var(--border); background: linear-gradient(90deg, #171d2b, #111524); }
+    .modal-header { display:flex; align-items:center; justify-content:space-between; padding:16px 18px; border-bottom:1px solid var(--border); background: var(--stack-header-bg); }
     .modal-title { font-weight:800; font-size:1rem; letter-spacing:0.02em; }
     .modal-close { background:none; border:none; color:var(--muted); font-size:1.2rem; cursor:pointer; }
     .modal-tabs { display:flex; gap:8px; padding:12px 16px 0; border-bottom:1px solid var(--border); }
@@ -134,7 +134,7 @@
     .stats-row { display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:12px; }
     .stat-box { background: var(--panel); border:1px solid var(--border); border-radius:12px; padding:10px 12px; display:flex; flex-direction:column; gap:6px; }
     canvas { width:100%; height:160px; background: radial-gradient(circle at 20% 20%, rgba(49,196,255,0.05), transparent 35%); border-radius:10px; }
-    .logs-area { background: #0d1018; border:1px solid var(--border); border-radius:12px; padding:10px; font-family:"JetBrains Mono", monospace; font-size:0.8rem; max-height:380px; overflow:auto; white-space:pre-wrap; }
+    .logs-area { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:12px; padding:10px; font-family:"JetBrains Mono", monospace; font-size:0.8rem; max-height:380px; overflow:auto; white-space:pre-wrap; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.02); }
     .logs-panel .logs-area { flex:1; max-height:unset; min-height:0; }
     .logs-area .log-line { padding:4px 8px; border-left:3px solid transparent; margin-bottom:2px; border-radius:8px; display:flex; gap:8px; align-items:flex-start; }
     .logs-area .log-line:last-child { margin-bottom:0; }
@@ -142,11 +142,12 @@
     .logs-area .log-info { border-color: var(--accent); background:rgba(49,196,255,0.06); }
     .logs-area .log-warn { border-color:#ffd54f; background:rgba(255,213,79,0.07); }
     .logs-area .log-error { border-color:#ff8a7a; background:rgba(255,138,122,0.08); }
-    .logs-area .log-debug { border-color:#9aa7bd; background:rgba(154,167,189,0.06); color:#c5cee0; }
+    .logs-area .log-debug { border-color:#9aa7bd; background:rgba(154,167,189,0.08); color: var(--text); }
     .logs-area .log-other { border-color:rgba(255,255,255,0.08); }
     .controls { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
     .select, .input { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
-    .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background:#1d2535; color: var(--text); cursor:pointer; }
+    .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background: var(--control-surface); color: var(--text); cursor:pointer; }
+    .inline-btn:hover { border-color: var(--accent-border); color: var(--accent); box-shadow: 0 6px 18px var(--accent-glow-soft); }
     .chip { background: rgba(255,255,255,0.05); border:1px solid var(--border); padding:4px 8px; border-radius:8px; font-size:0.8rem; }
     .small { font-size:0.8rem; color:var(--muted); }
     .table-kv { width:100%; border-collapse:collapse; }

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -215,22 +215,22 @@
     .modal-backdrop { position: fixed; inset:0; background: rgba(0,0,0,0.65); display:none; align-items:center; justify-content:center; z-index: 50; padding:20px; }
     .modal-backdrop.visible { display:flex; }
     .modal { background: var(--panel-2); border:1px solid var(--border); border-radius:16px; width:min(960px, 100%); height:72vh; max-height:72vh; overflow:hidden; box-shadow: var(--shadow); display:flex; flex-direction:column; }
-    .modal-header { display:flex; align-items:center; justify-content:space-between; padding:16px 18px; border-bottom:1px solid var(--border); background: linear-gradient(90deg, #171d2b, #111524); }
+    .modal-header { display:flex; align-items:center; justify-content:space-between; padding:16px 18px; border-bottom:1px solid var(--border); background: var(--stack-header-bg); }
     .modal-title { font-weight:800; font-size:1rem; letter-spacing:0.02em; }
     .modal-close { background:none; border:none; color:var(--muted); font-size:1.2rem; cursor:pointer; }
     .modal-body { padding:16px; overflow-y:auto; flex:1; display:flex; flex-direction:column; gap:12px; min-height:0; }
     .inline-controls { display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
-    .inline-controls .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.05); color: var(--text); cursor:pointer; transition: all 0.15s ease; }
-    .inline-controls .inline-btn:hover { border-color: var(--accent-border); color: var(--accent); }
+    .inline-controls .inline-btn { padding:8px 12px; border-radius:10px; border:1px solid var(--border); background: var(--control-surface); color: var(--text); cursor:pointer; transition: all 0.15s ease; }
+    .inline-controls .inline-btn:hover { border-color: var(--accent-border); color: var(--accent); box-shadow: 0 6px 18px var(--accent-glow-soft); }
     .select { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
-    .logs-area { background: #0d1018; border:1px solid var(--border); border-radius:12px; padding:10px; font-family:"JetBrains Mono", monospace; font-size:0.85rem; max-height:100%; overflow:auto; white-space:pre-wrap; }
+    .logs-area { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:12px; padding:10px; font-family:"JetBrains Mono", monospace; font-size:0.85rem; max-height:100%; overflow:auto; white-space:pre-wrap; box-shadow: inset 0 0 0 1px rgba(0,0,0,0.02); }
     .logs-area .log-line { padding:4px 8px; border-left:3px solid transparent; margin-bottom:2px; border-radius:8px; display:flex; gap:8px; align-items:flex-start; }
     .logs-area .log-line:last-child { margin-bottom:0; }
     .logs-area .log-bullet { opacity:0.4; }
     .logs-area .log-info { border-color: var(--accent); background:rgba(49,196,255,0.06); }
     .logs-area .log-warn { border-color:#ffd54f; background:rgba(255,213,79,0.07); }
     .logs-area .log-error { border-color:#ff8a7a; background:rgba(255,138,122,0.08); }
-    .logs-area .log-debug { border-color:#9aa7bd; background:rgba(154,167,189,0.06); color:#c5cee0; }
+    .logs-area .log-debug { border-color:#9aa7bd; background:rgba(154,167,189,0.08); color: var(--text); }
     .logs-area .log-other { border-color:rgba(255,255,255,0.08); }
     .pill {
       padding: 4px 10px;

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -85,10 +85,10 @@
     .col-version { width: 160px; }
     .col-log, .col-breaking { width: 200px; }
     .col-actions { width: 180px; }
-    .btn { border: none; border-radius: 12px; padding: 8px 14px; font-size: 0.85rem; cursor: pointer; background: linear-gradient(135deg, #1f2a3c, #26324a); color: #e7ecf4; transition: transform 0.08s ease, box-shadow 0.2s ease, filter 0.2s ease; text-align: center; border:1px solid var(--border); box-shadow: 0 8px 18px rgba(0,0,0,0.35); }
-    .btn:hover { transform: translateY(-1px); filter: brightness(1.05); box-shadow: 0 10px 22px rgba(0,0,0,0.45); }
-    .btn-full-update { background: linear-gradient(135deg, #1fb1ff, #4bd1ff); color:#04101c; font-weight: 800; letter-spacing: 0.01em; }
-    .btn-full-update:hover { filter: brightness(1.1); }
+    .btn { border: 1px solid var(--border); border-radius: 12px; padding: 8px 14px; font-size: 0.85rem; cursor: pointer; background: var(--control-surface); color: var(--text); transition: transform 0.08s ease, box-shadow 0.2s ease, filter 0.2s ease; text-align: center; box-shadow: 0 8px 18px var(--shadow); }
+    .btn:hover { transform: translateY(-1px); filter: brightness(1.02); box-shadow: 0 10px 22px var(--accent-glow-soft); color: var(--accent); border-color: var(--accent-border); }
+    .btn-full-update { background: var(--accent-gradient); color:#04101c; font-weight: 800; letter-spacing: 0.01em; border-color: var(--accent-border); box-shadow: 0 10px 22px var(--accent-glow); }
+    .btn-full-update:hover { filter: brightness(1.05); color: #0b111c; }
     .small { font-size: 0.82rem; color: #adb7c7; }
     .performance-hint { display:none; margin-top: 8px; padding: 10px 12px; border-radius: 12px; background: rgba(255,255,255,0.04); border:1px dashed var(--border); align-items: center; gap: 12px; }
     .performance-hint.visible { display: flex; justify-content: space-between; flex-wrap: wrap; }
@@ -113,7 +113,7 @@
     .confirm-modal { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; width:min(420px, 100%); box-shadow: var(--shadow); display:flex; flex-direction:column; gap:12px; }
     .confirm-title { margin:0; font-size:1rem; }
     .confirm-actions { display:flex; justify-content:flex-end; gap:8px; }
-    .btn-ghost { background: rgba(255,255,255,0.04); color: var(--text); }
+    .btn-ghost { background: var(--control-surface); color: var(--text); border-color: var(--border); }
     .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
     .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
     .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }


### PR DESCRIPTION
## Summary
- align modal headers, log panels, and inline controls with theme variables for better contrast in light mode
- harmonize container selection bar and control buttons with the active theme
- restyle update actions to use theme accent colors instead of dark defaults

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923039c1bf8832dbdeaf97137373020)