### PR TITLE
Add onboarding language and theme chooser

### DIFF
--- a/d2ha/templates/setup_2fa.html
+++ b/d2ha/templates/setup_2fa.html
@@ -70,6 +70,64 @@
       padding: 20px 22px;
       box-shadow: var(--shadow);
     }
+    .onboarding-toolbar {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      z-index: 20;
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+      pointer-events: none;
+      padding: 0 8px;
+    }
+    .onboarding-toggle {
+      pointer-events: auto;
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font-size: 1rem;
+      cursor: pointer;
+      box-shadow: var(--shadow);
+    }
+    .onboarding-menu {
+      position: absolute;
+      top: 52px;
+      right: 14px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      padding: 12px;
+      min-width: 240px;
+      display: none;
+      pointer-events: auto;
+    }
+    .onboarding-menu.open { display: block; }
+    .onboarding-menu h2 {
+      margin: 0 0 10px;
+      font-size: 0.95rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+    .onboarding-menu form {
+      margin: 0 0 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
+    .onboarding-menu select {
+      width: 100%;
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      font-size: 0.95rem;
+    }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
     .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
@@ -92,6 +150,32 @@
   </style>
 </head>
 <body class="theme-{{ get_current_theme() }}">
+  <div class="onboarding-toolbar">
+    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
+    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
+      <h2>{{ t('settings.title') }}</h2>
+      <form method="post" action="{{ url_for('set_language') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-lang">{{ t('language.label') }}</label>
+        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
+          {% for lang_code in SUPPORTED_LANGS %}
+          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
+            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
+          </option>
+          {% endfor %}
+        </select>
+      </form>
+      <form method="post" action="{{ url_for('set_theme') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-theme">{{ t('theme.label') }}</label>
+        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
+          {% for theme in SUPPORTED_THEMES %}
+          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
+          {% endfor %}
+        </select>
+      </form>
+    </div>
+  </div>
   <div class="card">
     <h1>Autenticazione a due fattori</h1>
     <p>Aggiungi un secondo fattore di sicurezza: ad ogni login, oltre a username e password, ti verrà chiesto un codice temporaneo generato sul tuo smartphone.</p>
@@ -134,5 +218,22 @@
       </div>
     </form>
   </div>
+  <script>
+    const onboardingToggle = document.getElementById('onboardingToggle');
+    const onboardingMenu = document.getElementById('onboardingMenu');
+
+    onboardingToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      onboardingMenu.classList.toggle('open');
+      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
+        onboardingMenu.classList.remove('open');
+        onboardingToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
 </body>
 </html>

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -70,6 +70,64 @@
       padding: 20px 22px;
       box-shadow: var(--shadow);
     }
+    .onboarding-toolbar {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      z-index: 20;
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+      pointer-events: none;
+      padding: 0 8px;
+    }
+    .onboarding-toggle {
+      pointer-events: auto;
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font-size: 1rem;
+      cursor: pointer;
+      box-shadow: var(--shadow);
+    }
+    .onboarding-menu {
+      position: absolute;
+      top: 52px;
+      right: 14px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      padding: 12px;
+      min-width: 240px;
+      display: none;
+      pointer-events: auto;
+    }
+    .onboarding-menu.open { display: block; }
+    .onboarding-menu h2 {
+      margin: 0 0 10px;
+      font-size: 0.95rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+    .onboarding-menu form {
+      margin: 0 0 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
+    .onboarding-menu select {
+      width: 100%;
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      font-size: 0.95rem;
+    }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
     .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
@@ -86,6 +144,32 @@
   </style>
 </head>
 <body class="theme-{{ get_current_theme() }}">
+  <div class="onboarding-toolbar">
+    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
+    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
+      <h2>{{ t('settings.title') }}</h2>
+      <form method="post" action="{{ url_for('set_language') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-lang">{{ t('language.label') }}</label>
+        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
+          {% for lang_code in SUPPORTED_LANGS %}
+          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
+            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
+          </option>
+          {% endfor %}
+        </select>
+      </form>
+      <form method="post" action="{{ url_for('set_theme') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-theme">{{ t('theme.label') }}</label>
+        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
+          {% for theme in SUPPORTED_THEMES %}
+          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
+          {% endfor %}
+        </select>
+      </form>
+    </div>
+  </div>
   <div class="card">
     <h1>Proteggi il tuo accesso</h1>
     <p>Stai accedendo con le credenziali predefinite <strong>admin / admin</strong>. Per sicurezza devi scegliere una nuova password (e, se vuoi, anche un nuovo username). La vecchia password smetterà di funzionare.</p>
@@ -122,5 +206,22 @@
       <button type="submit" class="btn">Continua</button>
     </form>
   </div>
+  <script>
+    const onboardingToggle = document.getElementById('onboardingToggle');
+    const onboardingMenu = document.getElementById('onboardingMenu');
+
+    onboardingToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      onboardingMenu.classList.toggle('open');
+      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
+        onboardingMenu.classList.remove('open');
+        onboardingToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
 </body>
 </html>

--- a/d2ha/templates/setup_autodiscovery.html
+++ b/d2ha/templates/setup_autodiscovery.html
@@ -70,6 +70,64 @@
       padding: 20px 22px;
       box-shadow: var(--shadow);
     }
+    .onboarding-toolbar {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      z-index: 20;
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+      pointer-events: none;
+      padding: 0 8px;
+    }
+    .onboarding-toggle {
+      pointer-events: auto;
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font-size: 1rem;
+      cursor: pointer;
+      box-shadow: var(--shadow);
+    }
+    .onboarding-menu {
+      position: absolute;
+      top: 52px;
+      right: 14px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      padding: 12px;
+      min-width: 240px;
+      display: none;
+      pointer-events: auto;
+    }
+    .onboarding-menu.open { display: block; }
+    .onboarding-menu h2 {
+      margin: 0 0 10px;
+      font-size: 0.95rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+    .onboarding-menu form {
+      margin: 0 0 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
+    .onboarding-menu select {
+      width: 100%;
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      font-size: 0.95rem;
+    }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
     .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
@@ -86,6 +144,32 @@
   </style>
 </head>
 <body class="theme-{{ get_current_theme() }}">
+  <div class="onboarding-toolbar">
+    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
+    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
+      <h2>{{ t('settings.title') }}</h2>
+      <form method="post" action="{{ url_for('set_language') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-lang">{{ t('language.label') }}</label>
+        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
+          {% for lang_code in SUPPORTED_LANGS %}
+          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
+            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
+          </option>
+          {% endfor %}
+        </select>
+      </form>
+      <form method="post" action="{{ url_for('set_theme') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-theme">{{ t('theme.label') }}</label>
+        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
+          {% for theme in SUPPORTED_THEMES %}
+          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
+          {% endfor %}
+        </select>
+      </form>
+    </div>
+  </div>
   <div class="card">
     <h1>Autodiscovery MQTT e Home Assistant</h1>
     <p>Docker2HomeAssistant può esporre automaticamente entità MQTT verso Home Assistant tramite autodiscovery.</p>
@@ -118,5 +202,22 @@
     </form>
 
   </div>
+  <script>
+    const onboardingToggle = document.getElementById('onboardingToggle');
+    const onboardingMenu = document.getElementById('onboardingMenu');
+
+    onboardingToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      onboardingMenu.classList.toggle('open');
+      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
+        onboardingMenu.classList.remove('open');
+        onboardingToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
 </body>
 </html>

--- a/d2ha/templates/setup_modes.html
+++ b/d2ha/templates/setup_modes.html
@@ -70,6 +70,64 @@
       padding: 20px 22px;
       box-shadow: var(--shadow);
     }
+    .onboarding-toolbar {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      z-index: 20;
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+      pointer-events: none;
+      padding: 0 8px;
+    }
+    .onboarding-toggle {
+      pointer-events: auto;
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font-size: 1rem;
+      cursor: pointer;
+      box-shadow: var(--shadow);
+    }
+    .onboarding-menu {
+      position: absolute;
+      top: 52px;
+      right: 14px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      padding: 12px;
+      min-width: 240px;
+      display: none;
+      pointer-events: auto;
+    }
+    .onboarding-menu.open { display: block; }
+    .onboarding-menu h2 {
+      margin: 0 0 10px;
+      font-size: 0.95rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+    .onboarding-menu form {
+      margin: 0 0 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
+    .onboarding-menu select {
+      width: 100%;
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      font-size: 0.95rem;
+    }
     h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
     p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
     .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
@@ -85,6 +143,32 @@
   </style>
 </head>
 <body class="theme-{{ get_current_theme() }}">
+  <div class="onboarding-toolbar">
+    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
+    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
+      <h2>{{ t('settings.title') }}</h2>
+      <form method="post" action="{{ url_for('set_language') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-lang">{{ t('language.label') }}</label>
+        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
+          {% for lang_code in SUPPORTED_LANGS %}
+          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
+            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
+          </option>
+          {% endfor %}
+        </select>
+      </form>
+      <form method="post" action="{{ url_for('set_theme') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-theme">{{ t('theme.label') }}</label>
+        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
+          {% for theme in SUPPORTED_THEMES %}
+          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
+          {% endfor %}
+        </select>
+      </form>
+    </div>
+  </div>
   <div class="card">
     <h1>Modalità del sistema</h1>
     <p>Queste opzioni ti aiutano a bilanciare sicurezza e prestazioni. Puoi sempre modificarle in seguito dal pulsante con l'icona dell'ingranaggio in alto a destra.</p>
@@ -115,5 +199,22 @@
       <button type="submit">Continua</button>
     </form>
   </div>
+  <script>
+    const onboardingToggle = document.getElementById('onboardingToggle');
+    const onboardingMenu = document.getElementById('onboardingMenu');
+
+    onboardingToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      onboardingMenu.classList.toggle('open');
+      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
+        onboardingMenu.classList.remove('open');
+        onboardingToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a floating quick settings toolbar to onboarding wizard pages
- allow selecting default language and theme directly during first-run setup

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69230fbdacc4832d896c19f87344c611)