### PR TITLE
Align login language and theme selectors with onboarding toolbar

### DIFF
--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -62,6 +62,64 @@
       justify-content: center;
       padding: 18px;
     }
+    .onboarding-toolbar {
+      position: fixed;
+      top: 12px;
+      right: 12px;
+      z-index: 20;
+      display: flex;
+      justify-content: flex-end;
+      width: 100%;
+      pointer-events: none;
+      padding: 0 8px;
+    }
+    .onboarding-toggle {
+      pointer-events: auto;
+      background: var(--panel);
+      color: var(--text);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      font-size: 1rem;
+      cursor: pointer;
+      box-shadow: var(--shadow);
+    }
+    .onboarding-menu {
+      position: absolute;
+      top: 52px;
+      right: 14px;
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      box-shadow: var(--shadow);
+      padding: 12px;
+      min-width: 240px;
+      display: none;
+      pointer-events: auto;
+    }
+    .onboarding-menu.open { display: block; }
+    .onboarding-menu h2 {
+      margin: 0 0 10px;
+      font-size: 0.95rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+    .onboarding-menu form {
+      margin: 0 0 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
+    .onboarding-menu select {
+      width: 100%;
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      font-size: 0.95rem;
+    }
     .card {
       width: min(460px, 100%);
       background: linear-gradient(160deg, var(--accent-surface), rgba(124,255,195,0.06)), var(--panel);
@@ -103,6 +161,32 @@
   </style>
 </head>
 <body class="theme-{{ get_current_theme() }}">
+  <div class="onboarding-toolbar">
+    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
+    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
+      <h2>{{ t('settings.title') }}</h2>
+      <form method="post" action="{{ url_for('set_language') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-lang">{{ t('language.label') }}</label>
+        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
+          {% for lang_code in SUPPORTED_LANGS %}
+            <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
+              {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
+            </option>
+          {% endfor %}
+        </select>
+      </form>
+      <form method="post" action="{{ url_for('set_theme') }}">
+        <input type="hidden" name="next" value="{{ request.path }}">
+        <label for="onboarding-theme">{{ t('theme.label') }}</label>
+        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
+          {% for theme in SUPPORTED_THEMES %}
+          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
+          {% endfor %}
+        </select>
+      </form>
+    </div>
+  </div>
   <div class="card">
     <h1>{{ t("login.heading") }}</h1>
     {% if show_onboarding_hint %}
@@ -137,27 +221,23 @@
       {% endif %}
       <button type="submit" class="btn">{{ t("login.button") }}</button>
     </form>
-    <div class="flash-container" style="margin-top:12px; gap:10px;">
-      <form method="post" action="{{ url_for('set_language') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="login-lang" class="hint">{{ t('language.label') }}</label>
-        <select id="login-lang" name="lang" onchange="this.form.submit()">
-          {% for lang_code in SUPPORTED_LANGS %}
-            <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
-              {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
-            </option>
-          {% endfor %}
-        </select>
-      </form>
-      <form method="post" action="{{ url_for('set_theme') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="login-theme" class="hint">{{ t('theme.label') }}</label>
-        <select id="login-theme" name="theme" onchange="this.form.submit()">
-          <option value="dark" {% if get_current_theme() == 'dark' %}selected{% endif %}>{{ t('theme.dark') }}</option>
-          <option value="light" {% if get_current_theme() == 'light' %}selected{% endif %}>{{ t('theme.light') }}</option>
-        </select>
-      </form>
-    </div>
   </div>
+  <script>
+    const onboardingToggle = document.getElementById('onboardingToggle');
+    const onboardingMenu = document.getElementById('onboardingMenu');
+
+    onboardingToggle.addEventListener('click', (event) => {
+      event.stopPropagation();
+      onboardingMenu.classList.toggle('open');
+      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
+        onboardingMenu.classList.remove('open');
+        onboardingToggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a top-right onboarding toolbar on the login page to mirror the wizard controls
- move language and theme selectors into the toggleable settings menu and use supported theme options
- remove inline selectors from the login form while keeping existing styling and behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232ef2369c832dac8ce58c34a26f55)