### PR TITLE
Initialize security settings defaults before onboarding

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -475,12 +475,12 @@ def setup_autodiscovery():
 def security_settings():
     config = get_auth_config()
 
+    provisioning_uri = None
+    qr_code_data_uri = None
+    pending_2fa_setup = False
+
     if not is_onboarding_done():
         return redirect(url_for("setup_account"))
-
-        provisioning_uri = None
-        qr_code_data_uri = None
-        pending_2fa_setup = False
 
     def _require_current_password(value: str) -> bool:
         if not check_password_hash(config.get("password_hash", ""), value):


### PR DESCRIPTION
## Summary
- initialize security settings defaults before onboarding check to avoid undefined variables
- keep security page rendering stable when onboarding is complete

## Testing
- python -m compileall d2ha


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692335c23b54832d9a8230c28aadbded)