### PR TITLE
Add floating auto-dismissing flash messages

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -102,11 +102,6 @@
     .col-image { width: 220px; }
     .col-status { width: 140px; }
     .col-pref { width: 260px; }
-    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
-    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 960px) {
       table { min-width: 720px; }
       th, td { font-size:0.82rem; }
@@ -131,15 +126,7 @@
     </nav>
   </header>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      <div class="flash-container">
-        {% for category, msg in messages %}
-          <div class="flash {{ category }}">{{ msg }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% include 'partials/flash_messages.html' %}
 
   <main>
     <section class="card">

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -166,11 +166,6 @@
     .toast-success { border-color: rgba(124,255,195,0.25); }
     .toast-error { border-color: rgba(255,138,122,0.25); }
     .toast-warning { border-color: rgba(255,213,79,0.35); }
-    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
-    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -198,15 +193,7 @@
     </nav>
   </header>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      <div class="flash-container">
-        {% for category, msg in messages %}
-          <div class="flash {{ category }}">{{ msg }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% include 'partials/flash_messages.html' %}
 
   <main>
     <div class="card">

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -99,11 +99,6 @@
     .muted { color: var(--muted); font-size:0.85rem; }
     .badge { padding:4px 8px; border-radius:8px; background: rgba(255,255,255,0.05); border:1px solid var(--border); font-size:0.8rem; }
     .empty { padding:18px; text-align:center; color: var(--muted); }
-    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
-    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media (max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -131,15 +126,7 @@
     </nav>
   </header>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      <div class="flash-container">
-        {% for category, msg in messages %}
-          <div class="flash {{ category }}">{{ msg }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% include 'partials/flash_messages.html' %}
 
   <main>
     <section class="card filters">

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -372,23 +372,6 @@
       border-radius: 50%;
       display: inline-block;
     }
-    .flash-container {
-      margin: 12px 18px 0;
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-    .flash {
-      padding: 12px 14px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: rgba(255,255,255,0.04);
-      color: var(--text);
-      box-shadow: var(--shadow);
-    }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media (max-width: 960px) {
       .layout { grid-template-columns: 1fr; }
     }
@@ -413,15 +396,7 @@
     </nav>
   </header>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      <div class="flash-container">
-        {% for category, msg in messages %}
-          <div class="flash {{ category }}">{{ msg }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% include 'partials/flash_messages.html' %}
 
   <div class="layout">
     <aside>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -75,11 +75,6 @@
     .btn:hover { background:#31394e; transform: translateY(-1px); }
     .btn-danger { background:#b71c1c; }
     .btn:disabled { opacity:0.4; cursor:not-allowed; transform:none; }
-    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
-    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -107,15 +102,7 @@
     </nav>
   </header>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      <div class="flash-container">
-        {% for category, msg in messages %}
-          <div class="flash {{ category }}">{{ msg }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% include 'partials/flash_messages.html' %}
 
   <main>
     <div class="card">

--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -153,10 +153,6 @@
       box-shadow: 0 8px 18px var(--accent-glow);
     }
     .btn:hover { filter: brightness(1.05); }
-    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
-    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .hint { font-size: 0.9rem; color: var(--muted); }
   </style>
 </head>
@@ -193,15 +189,7 @@
     <p>{{ t("login.onboarding_hint")|safe }}</p>
     {% endif %}
 
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        <div class="flash-container">
-          {% for category, msg in messages %}
-            <div class="flash {{ category }}">{{ msg }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% include 'partials/flash_messages.html' %}
 
     <form method="post" autocomplete="off">
       <div>

--- a/d2ha/templates/partials/flash_messages.html
+++ b/d2ha/templates/partials/flash_messages.html
@@ -1,0 +1,73 @@
+{% with messages = get_flashed_messages(with_categories=True) %}
+  {% if messages %}
+    <style>
+      .flash-toast-container {
+        position: fixed;
+        top: 14px;
+        left: 0;
+        right: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 10px;
+        padding: 0 16px;
+        pointer-events: none;
+        z-index: 90;
+      }
+      .flash-toast {
+        background: linear-gradient(145deg, var(--control-surface), var(--panel));
+        color: var(--text);
+        border: 1px solid var(--border);
+        border-radius: 12px;
+        padding: 12px 14px;
+        box-shadow: var(--shadow);
+        min-width: min(440px, 92vw);
+        opacity: 0;
+        transform: translateY(-10px) scale(0.98);
+        transition: opacity 0.3s ease, transform 0.3s ease;
+        pointer-events: auto;
+        font-weight: 700;
+        text-align: center;
+      }
+      .flash-toast.visible {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+      }
+      .flash-toast.success { border-color: rgba(124, 255, 195, 0.35); box-shadow: 0 10px 28px rgba(124, 255, 195, 0.16); }
+      .flash-toast.error { border-color: rgba(255, 138, 122, 0.4); box-shadow: 0 10px 28px rgba(255, 138, 122, 0.2); }
+      .flash-toast.info { border-color: var(--accent-border); box-shadow: 0 10px 28px var(--accent-glow-soft); }
+      .flash-toast.warning { border-color: rgba(255, 213, 79, 0.4); box-shadow: 0 10px 28px rgba(255, 213, 79, 0.18); }
+    </style>
+    <div class="flash-toast-container" id="flash-toast-container" aria-live="polite">
+      {% for category, msg in messages %}
+        <div class="flash-toast {{ category }}">{{ msg }}</div>
+      {% endfor %}
+    </div>
+    <script>
+      (() => {
+        const container = document.getElementById('flash-toast-container');
+        if (!container) return;
+        const toasts = Array.from(container.querySelectorAll('.flash-toast'));
+        const displayMs = 4200;
+        const stagger = 80;
+
+        toasts.forEach((toast, index) => {
+          const showDelay = 20 + index * stagger;
+          const hideDelay = displayMs + index * stagger;
+          const removeDelay = hideDelay + 350;
+
+          setTimeout(() => toast.classList.add('visible'), showDelay);
+          setTimeout(() => toast.classList.remove('visible'), hideDelay);
+          setTimeout(() => toast.remove(), removeDelay);
+        });
+
+        const cleanupDelay = displayMs + 800 + toasts.length * stagger;
+        setTimeout(() => {
+          if (!container.children.length) {
+            container.remove();
+          }
+        }, cleanupDelay);
+      })();
+    </script>
+  {% endif %}
+{% endwith %}

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -165,12 +165,6 @@
     .status.on { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); color: #7cffc3; }
     .status.off { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); color: #ff8d8d; }
     .section-title { font-size: 1rem; margin: 16px 0 6px; color: var(--muted); }
-    .flash-container { margin: 18px 0 4px; display: grid; gap: 8px; }
-    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
-    .flash.warning { border-color: rgba(255,192,99,0.5); background: rgba(255,192,99,0.08); }
     .pending-box { margin-top: 12px; padding: 12px; border-radius: 12px; border: 1px dashed var(--accent-border); background: var(--accent-surface); }
     .qr-box { display: grid; gap: 10px; align-items: center; grid-template-columns: auto 1fr; }
     .qr-box img { background: white; padding: 8px; border-radius: 10px; }
@@ -197,15 +191,7 @@
   </header>
 
   <div class="container">
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        <div class="flash-container">
-          {% for category, msg in messages %}
-            <div class="flash {{ category }}">{{ msg }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% include 'partials/flash_messages.html' %}
 
     <div class="card">
       <h2>Impostazioni di sicurezza</h2>

--- a/d2ha/templates/setup_2fa.html
+++ b/d2ha/templates/setup_2fa.html
@@ -137,10 +137,6 @@
     .btn-primary { background: var(--accent-gradient); color: #0c121e; box-shadow: 0 8px 18px var(--accent-glow); }
     .btn-secondary { background: rgba(255,255,255,0.06); color: var(--text); border:1px solid var(--border); }
     input[type="text"] { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
-    .flash-container { margin: 12px 0; display: flex; flex-direction: column; gap: 8px; }
-    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .layout { display: grid; grid-template-columns: 1fr 1.4fr; gap: 18px; align-items: flex-start; margin: 14px 0; }
     .qr-box { background: var(--panel-2); border: 1px solid var(--border); border-radius: 12px; padding: 12px; text-align: center; box-shadow: var(--shadow); }
     .qr-title { margin: 0 0 8px; font-weight: 800; letter-spacing: 0.06em; color: var(--muted); text-transform: uppercase; font-size: 0.85rem; }
@@ -181,15 +177,7 @@
     <p>{{ t('setup_2fa.intro') }}</p>
     <p>{{ t('setup_2fa.hint') }}</p>
 
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        <div class="flash-container">
-          {% for category, msg in messages %}
-            <div class="flash {{ category }}">{{ msg }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% include 'partials/flash_messages.html' %}
 
     <div class="note">
       <p>{{ t('setup_2fa.step1') }}</p>

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -136,10 +136,6 @@
     input { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
     .btn { margin-top: 6px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: 0 8px 18px var(--accent-glow); }
     .btn:hover { filter: brightness(1.05); }
-    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
-    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     ul { margin: 0 0 10px 20px; color: var(--muted); }
   </style>
 </head>
@@ -180,15 +176,7 @@
       <li>{{ t('setup_account.tip_username').format(current_username=current_username) }}</li>
     </ul>
 
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        <div class="flash-container">
-          {% for category, msg in messages %}
-            <div class="flash {{ category }}">{{ msg }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% include 'partials/flash_messages.html' %}
 
     <form method="post" autocomplete="off">
       <div>

--- a/d2ha/templates/setup_autodiscovery.html
+++ b/d2ha/templates/setup_autodiscovery.html
@@ -136,10 +136,6 @@
     input[type="radio"] { width: 18px; height: 18px; accent-color: var(--accent); }
     button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
     button:hover { filter: brightness(1.05); }
-    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
-    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
     .hint { font-size: 0.85rem; opacity: 0.8; }
   </style>
 </head>
@@ -175,15 +171,7 @@
     <p>{{ t('setup_autodiscovery.intro') }}</p>
     <p>{{ t('setup_autodiscovery.hint') }}</p>
 
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        <div class="flash-container">
-          {% for category, msg in messages %}
-            <div class="flash {{ category }}">{{ msg }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% include 'partials/flash_messages.html' %}
 
     <form method="post">
       <label style="margin-bottom:8px;">

--- a/d2ha/templates/setup_modes.html
+++ b/d2ha/templates/setup_modes.html
@@ -136,9 +136,6 @@
     input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); }
     button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
     button:hover { filter: brightness(1.05); }
-    .flash-container { margin-bottom: 12px; display: flex; flex-direction: column; gap: 8px; }
-    .flash { padding: 12px 14px; border-radius: 10px; border: 1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
     .hint { font-size: 0.85rem; opacity: 0.8; margin-top: -6px; }
   </style>
 </head>
@@ -173,15 +170,7 @@
     <h1>{{ t('setup_modes.heading') }}</h1>
     <p>{{ t('setup_modes.description') }}</p>
 
-    {% with messages = get_flashed_messages(with_categories=True) %}
-      {% if messages %}
-        <div class="flash-container">
-          {% for category, msg in messages %}
-            <div class="flash {{ category }}">{{ msg }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+    {% include 'partials/flash_messages.html' %}
 
     <form method="post">
       <label style="display:flex;align-items:center;gap:8px;">

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -114,11 +114,6 @@
     .confirm-title { margin:0; font-size:1rem; }
     .confirm-actions { display:flex; justify-content:flex-end; gap:8px; }
     .btn-ghost { background: var(--control-surface); color: var(--text); border-color: var(--border); }
-    .flash-container { margin: 12px 18px 0; display:flex; flex-direction:column; gap:8px; }
-    .flash { padding:12px 14px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.04); color: var(--text); box-shadow: var(--shadow); }
-    .flash.success { border-color: rgba(124,255,195,0.4); background: rgba(124,255,195,0.08); }
-    .flash.error { border-color: rgba(255,99,99,0.4); background: rgba(255,99,99,0.08); }
-    .flash.info { border-color: var(--accent-border); background: var(--accent-surface); }
     @media(max-width: 1100px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -147,15 +142,7 @@
     </nav>
   </header>
 
-  {% with messages = get_flashed_messages(with_categories=True) %}
-    {% if messages %}
-      <div class="flash-container">
-        {% for category, msg in messages %}
-          <div class="flash {{ category }}">{{ msg }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  {% include 'partials/flash_messages.html' %}
 
   <main>
     <div class="card">


### PR DESCRIPTION
## Summary
- add a shared floating flash toast partial that animates and auto-dismisses system messages
- replace inline flash message blocks across templates to use the new top-of-page overlay

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923433b1a34832d858c4afff1989971)