### PR TITLE
Add animated canvas background for login and wizard pages

### DIFF
--- a/d2ha/static/css/auth.css
+++ b/d2ha/static/css/auth.css
@@ -1,0 +1,508 @@
+/* Auth animated tech background (login + wizard) */
+:root {
+  --bg: #0b1020;
+  --panel: rgba(17, 22, 36, 0.72);
+  --panel-2: rgba(26, 34, 52, 0.66);
+  --accent: #31c4ff;
+  --accent-2: #7cffc3;
+  --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+  --accent-glow: rgba(49, 196, 255, 0.35);
+  --accent-glow-soft: rgba(49, 196, 255, 0.18);
+  --accent-border-strong: rgba(49, 196, 255, 0.55);
+  --accent-border: rgba(49, 196, 255, 0.42);
+  --accent-border-soft: rgba(49, 196, 255, 0.28);
+  --accent-surface: rgba(49, 196, 255, 0.08);
+  --text: #e7ecf4;
+  --muted: #a7b1c6;
+  --border: rgba(255, 255, 255, 0.08);
+  --shadow: 0 14px 42px rgba(0, 0, 0, 0.45);
+  --header-bg: linear-gradient(90deg, #0d111c, #12182a);
+  --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
+  --control-surface: #0f141f;
+  --auth-bg-1: #0a1024;
+  --auth-bg-2: #0f1b3f;
+  --auth-point: #8ee8ff;
+  --auth-line: #4ec9ff;
+  --auth-glow: rgba(78, 201, 255, 0.45);
+}
+
+body.theme-light {
+  --bg: #f8fbff;
+  --panel: rgba(255, 255, 255, 0.72);
+  --panel-2: rgba(255, 255, 255, 0.64);
+  --accent: #1d9bf0;
+  --accent-2: #7cd4ff;
+  --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
+  --accent-glow: rgba(29, 155, 240, 0.25);
+  --accent-glow-soft: rgba(29, 155, 240, 0.18);
+  --accent-border-strong: rgba(29, 155, 240, 0.55);
+  --accent-border: rgba(29, 155, 240, 0.4);
+  --accent-border-soft: rgba(29, 155, 240, 0.22);
+  --accent-surface: rgba(29, 155, 240, 0.08);
+  --text: #0f172a;
+  --muted: #475569;
+  --border: rgba(15, 23, 42, 0.08);
+  --shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  --header-bg: linear-gradient(90deg, #e8f3ff, #d8ecff);
+  --stack-header-bg: linear-gradient(135deg, #e8f3ff, #cfe4ff);
+  --control-surface: #f2f7ff;
+  --auth-bg-1: #dbeafe;
+  --auth-bg-2: #b7d4f9;
+  --auth-point: #1d4ed8;
+  --auth-line: #0ea5e9;
+  --auth-glow: rgba(14, 165, 233, 0.28);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at 12% 18%, rgba(0, 255, 255, 0.05), transparent 26%),
+    radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.06), transparent 24%),
+    var(--bg);
+  color: var(--text);
+}
+
+.auth-page {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  overflow: hidden;
+}
+
+.auth-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.auth-overlay {
+  position: relative;
+  z-index: 2;
+  width: min(960px, 100%);
+}
+
+.auth-title {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 3;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: #eaf6ff;
+  font-weight: 800;
+  text-shadow: 0 0 16px rgba(78, 201, 255, 0.48), 0 0 32px rgba(124, 255, 195, 0.32);
+  font-size: clamp(1.1rem, 2vw + 0.6rem, 1.5rem);
+  opacity: 0.92;
+  pointer-events: none;
+}
+
+.auth-logo {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 3;
+  padding: 8px 10px;
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 12px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.auth-logo img {
+  display: block;
+  width: 120px;
+  height: auto;
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.35));
+}
+
+.auth-card {
+  width: min(520px, 100%);
+  margin: 0 auto;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, var(--accent-surface), rgba(124, 255, 195, 0.04)),
+    var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 22px 24px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px) saturate(115%);
+  position: relative;
+  overflow: hidden;
+}
+
+.auth-card::before {
+  content: "";
+  position: absolute;
+  inset: -30% auto auto -40%;
+  width: 320px;
+  height: 320px;
+  background: radial-gradient(circle, rgba(78, 201, 255, 0.18), transparent 60%);
+  filter: blur(10px);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.auth-card h1 {
+  margin: 0 0 8px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 1.1rem;
+  position: relative;
+  z-index: 1;
+}
+
+.auth-card p {
+  margin: 0 0 14px;
+  color: var(--muted);
+  line-height: 1.5;
+  position: relative;
+  z-index: 1;
+}
+
+.auth-card .pill {
+  display: inline-block;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--accent-surface);
+  color: var(--accent);
+  border: 1px solid var(--accent-border-soft);
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  position: relative;
+  z-index: 1;
+}
+
+.auth-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.auth-card label {
+  font-weight: 700;
+  color: var(--text);
+  font-size: 0.95rem;
+  display: block;
+}
+
+.auth-card input,
+.auth-card select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.auth-card input[type="radio"],
+.auth-card input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+.password-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.password-input-wrapper input {
+  padding-right: 44px;
+}
+
+.password-toggle {
+  position: absolute;
+  right: 10px;
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0.8;
+  transition: opacity 0.15s ease;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 4px;
+}
+
+.password-toggle:hover {
+  opacity: 1;
+}
+
+.btn,
+.auth-card button,
+.auth-card .btn-primary {
+  margin-top: 6px;
+  padding: 12px;
+  border: none;
+  border-radius: 14px;
+  background: var(--accent-gradient);
+  color: #0c121e;
+  font-weight: 800;
+  cursor: pointer;
+  box-shadow: 0 10px 22px var(--accent-glow);
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.btn:hover,
+.auth-card button:hover,
+.auth-card .btn-primary:hover {
+  filter: brightness(1.05);
+  transform: translateY(-1px);
+}
+
+.btn:active,
+.auth-card button:active,
+.auth-card .btn-primary:active {
+  transform: translateY(0);
+}
+
+.hint,
+.password-hint {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.strength-weak {
+  color: #f87171;
+}
+
+.strength-medium {
+  color: #fbbf24;
+}
+
+.strength-strong {
+  color: #7cffc3;
+}
+
+.note {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 12px 14px;
+  margin: 8px 0 16px;
+  color: var(--text);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 1.4fr;
+  gap: 18px;
+  align-items: flex-start;
+  margin: 14px 0;
+}
+
+.qr-box {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.qr-title {
+  margin: 0 0 8px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.qr-image {
+  width: 100%;
+  max-width: 210px;
+  height: auto;
+  image-rendering: crisp-edges;
+  border-radius: 10px;
+  background: #ffffff;
+  padding: 10px;
+}
+
+.section-title {
+  font-weight: 800;
+  margin: 0 0 6px;
+  letter-spacing: 0.04em;
+}
+
+.secret-box {
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 12px;
+  font-family: "JetBrains Mono", monospace;
+  margin: 8px 0;
+}
+
+.auth-actions-form {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.btn-secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--text);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.onboarding-toolbar {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  z-index: 4;
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
+  pointer-events: none;
+  padding: 0 8px;
+}
+
+.onboarding-toggle {
+  pointer-events: auto;
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  font-size: 1rem;
+  cursor: pointer;
+  box-shadow: var(--shadow);
+}
+
+.onboarding-menu {
+  position: absolute;
+  top: 52px;
+  right: 14px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  padding: 12px;
+  min-width: 240px;
+  display: none;
+  pointer-events: auto;
+  backdrop-filter: blur(10px);
+}
+
+.onboarding-menu.open {
+  display: block;
+}
+
+.onboarding-menu h2 {
+  margin: 0 0 10px;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.onboarding-menu form {
+  margin: 0 0 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.onboarding-menu label {
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.onboarding-menu select {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--panel-2);
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.auth-choice {
+  display: block;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.08);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.auth-choice + .auth-choice {
+  margin-top: 8px;
+}
+
+.auth-choice:hover {
+  border-color: var(--accent-border);
+  background: rgba(49, 196, 255, 0.05);
+}
+
+.auth-choice strong {
+  display: block;
+  color: var(--text);
+  margin-bottom: 4px;
+}
+
+.auth-choice .hint {
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .auth-card {
+    padding: 18px 16px;
+  }
+
+  .auth-overlay {
+    width: 100%;
+  }
+
+  .auth-title {
+    top: 12px;
+    font-size: 1rem;
+  }
+
+  .auth-logo img {
+    width: 100px;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .qr-box {
+    justify-self: center;
+    width: 100%;
+    max-width: 320px;
+  }
+}

--- a/d2ha/static/img/logo.svg
+++ b/d2ha/static/img/logo.svg
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Livello_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 200 200">
+  <!-- Generator: Adobe Illustrator 29.0.1, SVG Export Plug-In . SVG Version: 2.1.0 Build 192)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #4f4f4f;
+      }
+
+      .st1 {
+        fill: #fff;
+        stroke-miterlimit: 10;
+        stroke-width: 5px;
+      }
+
+      .st1, .st2 {
+        stroke: #fff;
+      }
+
+      .st2 {
+        stroke-width: 3px;
+      }
+
+      .st2, .st3 {
+        fill: none;
+      }
+
+      .st4 {
+        fill: #097;
+      }
+
+      .st5 {
+        font-family: ArialMT, Arial;
+        font-size: 4.7px;
+      }
+
+      .st5, .st6, .st7 {
+        isolation: isolate;
+      }
+
+      .st8, .st7 {
+        fill: #333;
+      }
+
+      .st7 {
+        font-family: Arial-BoldMT, Arial;
+        font-size: 20px;
+        font-weight: 700;
+      }
+    </style>
+  </defs>
+  <path class="st3" d="M0,0"/>
+  <g class="st6">
+    <g class="st6">
+      <text class="st7" transform="translate(67.3 122.2)"><tspan x="0" y="0">arBorae</tspan></text>
+    </g>
+  </g>
+  <path class="st8" d="M0,0"/>
+  <g>
+    <circle class="st4" cx="99.7" cy="59.5" r="32.3"/>
+    <g>
+      <g>
+        <line class="st2" x1="100" y1="44.3" x2="100" y2="73"/>
+        <line class="st2" x1="81" y1="64.3" x2="100.6" y2="73.8"/>
+        <line class="st2" x1="119" y1="64.3" x2="99.4" y2="73.8"/>
+      </g>
+      <g>
+        <circle class="st1" cx="100" cy="44.3" r="2.9"/>
+        <circle class="st1" cx="81" cy="64.3" r="2.9"/>
+        <circle class="st1" cx="119" cy="64.3" r="2.9"/>
+      </g>
+    </g>
+    <path class="st0" d="M100,75.2h0c2.8,0,5,2.2,5,5v21.9c0,2.8-2.2,5-5,5h0c-2.8,0-5-2.2-5-5v-21.9c0-2.8,2.2-5,5-5Z"/>
+  </g>
+  <g class="st6">
+    <g class="st6">
+      <text class="st5" transform="translate(3.1 129.2)"><tspan x="0" y="0">Adaptive Reconfigurable Backbone for Optimized Resource Automation and Energy Efficiency </tspan></text>
+    </g>
+  </g>
+</svg>

--- a/d2ha/static/js/auth_background.js
+++ b/d2ha/static/js/auth_background.js
@@ -1,0 +1,125 @@
+// Auth animated tech background (login + wizard)
+(() => {
+  const canvas = document.getElementById('authCanvas');
+  if (!canvas) return;
+
+  const ctx = canvas.getContext('2d');
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let width = 0;
+  let height = 0;
+  let gradient;
+  let particles = [];
+
+  const palette = () => {
+    const styles = getComputedStyle(document.body);
+    return {
+      bg1: styles.getPropertyValue('--auth-bg-1').trim() || '#0a1024',
+      bg2: styles.getPropertyValue('--auth-bg-2').trim() || '#0f1b3f',
+      point: styles.getPropertyValue('--auth-point').trim() || '#8ee8ff',
+      line: styles.getPropertyValue('--auth-line').trim() || '#4ec9ff',
+      glow: styles.getPropertyValue('--auth-glow').trim() || 'rgba(78,201,255,0.45)',
+    };
+  };
+
+  const randomBetween = (min, max) => Math.random() * (max - min) + min;
+
+  const createParticle = () => ({
+    x: Math.random() * width,
+    y: Math.random() * height,
+    radius: randomBetween(1.2, 2.6),
+    vx: randomBetween(-0.2, 0.2),
+    vy: randomBetween(-0.2, 0.2),
+  });
+
+  const resize = () => {
+    width = window.innerWidth;
+    height = window.innerHeight;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const colors = palette();
+    gradient = ctx.createLinearGradient(0, 0, width, height);
+    gradient.addColorStop(0, colors.bg1);
+    gradient.addColorStop(1, colors.bg2);
+
+    const targetCount = Math.max(40, Math.min(80, Math.floor(width / 18)));
+    if (particles.length === 0) {
+      particles = Array.from({ length: targetCount }, createParticle);
+    } else if (particles.length < targetCount) {
+      particles = particles.concat(Array.from({ length: targetCount - particles.length }, createParticle));
+    } else if (particles.length > targetCount) {
+      particles = particles.slice(0, targetCount);
+    }
+  };
+
+  const drawBackground = () => {
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, width, height);
+  };
+
+  const drawConnections = () => {
+    const { line, glow } = palette();
+    const maxDistance = Math.min(180, Math.max(120, width * 0.12));
+    for (let i = 0; i < particles.length; i += 1) {
+      for (let j = i + 1; j < particles.length; j += 1) {
+        const dx = particles[i].x - particles[j].x;
+        const dy = particles[i].y - particles[j].y;
+        const dist = Math.hypot(dx, dy);
+        if (dist <= maxDistance) {
+          const alpha = 1 - dist / maxDistance;
+          ctx.strokeStyle = line;
+          ctx.globalAlpha = alpha * 0.55;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(particles[i].x, particles[i].y);
+          ctx.lineTo(particles[j].x, particles[j].y);
+          ctx.stroke();
+          ctx.globalAlpha = 1;
+          if (alpha > 0.6) {
+            ctx.shadowBlur = 10;
+            ctx.shadowColor = glow;
+            ctx.stroke();
+            ctx.shadowBlur = 0;
+          }
+        }
+      }
+    }
+  };
+
+  const drawParticles = () => {
+    const { point, glow } = palette();
+    particles.forEach((p) => {
+      ctx.beginPath();
+      ctx.fillStyle = point;
+      ctx.shadowBlur = 18;
+      ctx.shadowColor = glow;
+      ctx.arc(p.x, p.y, p.radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.shadowBlur = 0;
+    });
+  };
+
+  const updateParticles = () => {
+    particles.forEach((p) => {
+      p.x += p.vx;
+      p.y += p.vy;
+      if (p.x < 0 || p.x > width) p.vx *= -1;
+      if (p.y < 0 || p.y > height) p.vy *= -1;
+    });
+  };
+
+  const render = () => {
+    drawBackground();
+    drawConnections();
+    drawParticles();
+    updateParticles();
+    requestAnimationFrame(render);
+  };
+
+  resize();
+  window.addEventListener('resize', resize);
+  render();
+})();

--- a/d2ha/templates/layouts/auth_base.html
+++ b/d2ha/templates/layouts/auth_base.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="{{ get_current_lang() }}">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}D2HA{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
+</head>
+<body class="theme-{{ get_current_theme() }}">
+  <div class="auth-page">
+    <!-- Auth animated tech background (login + wizard) -->
+    <canvas id="authCanvas" class="auth-canvas" aria-hidden="true"></canvas>
+    <div class="auth-title" aria-hidden="true">D2HA</div>
+    <div class="auth-logo" aria-hidden="true">
+      <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="D2HA Logo">
+    </div>
+
+    <div class="auth-overlay">
+      <div class="onboarding-toolbar">
+        <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
+        <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
+          <h2>{{ t('settings.title') }}</h2>
+          <form method="post" action="{{ url_for('set_language') }}">
+            <input type="hidden" name="next" value="{{ request.path }}">
+            <label for="onboarding-lang">{{ t('language.label') }}</label>
+            <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
+              {% for lang_code in SUPPORTED_LANGS %}
+              <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
+                {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
+              </option>
+              {% endfor %}
+            </select>
+          </form>
+          <form method="post" action="{{ url_for('set_theme') }}">
+            <input type="hidden" name="next" value="{{ request.path }}">
+            <label for="onboarding-theme">{{ t('theme.label') }}</label>
+            <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
+              {% for theme in SUPPORTED_THEMES %}
+              <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
+              {% endfor %}
+            </select>
+          </form>
+        </div>
+      </div>
+
+      <div class="auth-card">
+        {% block auth_content %}{% endblock %}
+      </div>
+    </div>
+  </div>
+
+  <script src="{{ url_for('static', filename='js/auth_background.js') }}"></script>
+  <script>
+    const onboardingToggle = document.getElementById('onboardingToggle');
+    const onboardingMenu = document.getElementById('onboardingMenu');
+
+    if (onboardingToggle && onboardingMenu) {
+      onboardingToggle.addEventListener('click', (event) => {
+        event.stopPropagation();
+        onboardingMenu.classList.toggle('open');
+        onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
+      });
+
+      document.addEventListener('click', (event) => {
+        if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
+          onboardingMenu.classList.remove('open');
+          onboardingToggle.setAttribute('aria-expanded', 'false');
+        }
+      });
+    }
+  </script>
+  {% block auth_scripts %}{% endblock %}
+</body>
+</html>

--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -1,251 +1,39 @@
-<!DOCTYPE html>
-<html lang="{{ get_current_lang() }}">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>{{ t("login.title") }}</title>
-  <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
-      --accent-2: #7cffc3;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(49,196,255,0.35);
-      --accent-glow-soft: rgba(49,196,255,0.25);
-      --accent-border-strong: rgba(49,196,255,0.55);
-      --accent-border: rgba(49,196,255,0.45);
-      --accent-border-soft: rgba(49,196,255,0.3);
-      --accent-surface: rgba(49,196,255,0.08);
-      --text: #e7ecf4;
-      --muted: #9aa7bd;
-      --border: rgba(255,255,255,0.08);
-      --shadow: 0 10px 30px rgba(0,0,0,0.45);
-      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
-      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
-      --control-surface: #0f141f;
-    }
+{% extends "layouts/auth_base.html" %}
+{% block title %}{{ t("login.title") }}{% endblock %}
 
-    body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
-      --accent-2: #fb923c;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
-      --accent-glow-soft: rgba(249,115,22,0.18);
-      --accent-border-strong: rgba(249,115,22,0.55);
-      --accent-border: rgba(249,115,22,0.42);
-      --accent-border-soft: rgba(249,115,22,0.26);
-      --accent-surface: rgba(249,115,22,0.08);
-      --text: #1f2937;
-      --muted: #4b5563;
-      --border: rgba(0,0,0,0.08);
-      --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
-      --control-surface: #fffaf3;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 88% 12%, rgba(124,255,195,0.06), transparent 22%),
-                  var(--bg);
-      color: var(--text);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 18px;
-    }
-    .onboarding-toolbar {
-      position: fixed;
-      top: 12px;
-      right: 12px;
-      z-index: 20;
-      display: flex;
-      justify-content: flex-end;
-      width: 100%;
-      pointer-events: none;
-      padding: 0 8px;
-    }
-    .onboarding-toggle {
-      pointer-events: auto;
-      background: var(--panel);
-      color: var(--text);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 10px 12px;
-      font-size: 1rem;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-menu {
-      position: absolute;
-      top: 52px;
-      right: 14px;
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      box-shadow: var(--shadow);
-      padding: 12px;
-      min-width: 240px;
-      display: none;
-      pointer-events: auto;
-    }
-    .onboarding-menu.open { display: block; }
-    .onboarding-menu h2 {
-      margin: 0 0 10px;
-      font-size: 0.95rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-    .onboarding-menu form {
-      margin: 0 0 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
-    .onboarding-menu select {
-      width: 100%;
-      padding: 8px 10px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: var(--panel-2);
-      color: var(--text);
-      font-size: 0.95rem;
-    }
-    .card {
-      width: min(460px, 100%);
-      background: linear-gradient(160deg, var(--accent-surface), rgba(124,255,195,0.06)), var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 20px 22px;
-      box-shadow: var(--shadow);
-    }
-    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
-    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
-    label { font-weight: 700; color: var(--text); font-size: 0.9rem; }
-    input {
-      width: 100%;
-      padding: 10px 12px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: var(--panel-2);
-      color: var(--text);
-      font-size: 1rem;
-    }
-    .password-input-wrapper { position: relative; display: flex; align-items: center; }
-    .password-input-wrapper input { padding-right: 42px; }
-    .password-toggle {
-      position: absolute;
-      right: 10px;
-      background: transparent;
-      border: none;
-      color: var(--muted);
-      cursor: pointer;
-      opacity: 0.75;
-      transition: opacity 0.15s ease;
-      font-size: 1rem;
-      line-height: 1;
-      padding: 4px;
-    }
-    .password-toggle:hover { opacity: 1; }
-    .btn {
-      margin-top: 6px;
-      padding: 12px;
-      border: none;
-      border-radius: 12px;
-      background: var(--accent-gradient);
-      color: #0c121e;
-      font-weight: 800;
-      cursor: pointer;
-      box-shadow: 0 8px 18px var(--accent-glow);
-    }
-    .btn:hover { filter: brightness(1.05); }
-    .hint { font-size: 0.9rem; color: var(--muted); }
-  </style>
-</head>
-<body class="theme-{{ get_current_theme() }}">
-  <div class="onboarding-toolbar">
-    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
-    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
-      <h2>{{ t('settings.title') }}</h2>
-      <form method="post" action="{{ url_for('set_language') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-lang">{{ t('language.label') }}</label>
-        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
-          {% for lang_code in SUPPORTED_LANGS %}
-            <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
-              {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
-            </option>
-          {% endfor %}
-        </select>
-      </form>
-      <form method="post" action="{{ url_for('set_theme') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-theme">{{ t('theme.label') }}</label>
-        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
-          {% for theme in SUPPORTED_THEMES %}
-          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
-          {% endfor %}
-        </select>
-      </form>
+{% block auth_content %}
+  <h1>{{ t("login.heading") }}</h1>
+  {% if show_onboarding_hint %}
+  <p>{{ t("login.onboarding_hint")|safe }}</p>
+  {% endif %}
+
+  {% include 'partials/flash_messages.html' %}
+
+  <form method="post" autocomplete="off">
+    <div>
+      <label for="username">{{ t("login.username") }}</label>
+      <input type="text" id="username" name="username" required />
     </div>
-  </div>
-  <div class="card">
-    <h1>{{ t("login.heading") }}</h1>
-    {% if show_onboarding_hint %}
-    <p>{{ t("login.onboarding_hint")|safe }}</p>
+    <div>
+      <label for="password">{{ t("login.password") }}</label>
+      <div class="password-input-wrapper">
+        <input type="password" id="password" name="password" required />
+        <button type="button" class="password-toggle" aria-label="{{ t('password.toggle.show') }}" title="{{ t('password.toggle.show') }}">👁</button>
+      </div>
+    </div>
+    {% if two_factor %}
+    <div>
+      <label for="token">{{ t("login.token") }}</label>
+      <input type="text" id="token" name="token" pattern="\d{6}" inputmode="numeric" autocomplete="one-time-code" />
+      <p class="hint">{{ t("wizard.step2.title") }}</p>
+    </div>
     {% endif %}
+    <button type="submit" class="btn">{{ t("login.button") }}</button>
+  </form>
+{% endblock %}
 
-    {% include 'partials/flash_messages.html' %}
-
-    <form method="post" autocomplete="off">
-      <div>
-        <label for="username">{{ t("login.username") }}</label>
-        <input type="text" id="username" name="username" required />
-      </div>
-      <div>
-        <label for="password">{{ t("login.password") }}</label>
-        <div class="password-input-wrapper">
-          <input type="password" id="password" name="password" required />
-          <button type="button" class="password-toggle" aria-label="{{ t('password.toggle.show') }}" title="{{ t('password.toggle.show') }}">👁</button>
-        </div>
-      </div>
-      {% if two_factor %}
-      <div>
-        <label for="token">{{ t("login.token") }}</label>
-        <input type="text" id="token" name="token" pattern="\d{6}" inputmode="numeric" autocomplete="one-time-code" />
-        <p class="hint">{{ t("wizard.step2.title") }}</p>
-      </div>
-      {% endif %}
-      <button type="submit" class="btn">{{ t("login.button") }}</button>
-    </form>
-  </div>
+{% block auth_scripts %}
   <script>
-    const onboardingToggle = document.getElementById('onboardingToggle');
-    const onboardingMenu = document.getElementById('onboardingMenu');
-
-    onboardingToggle.addEventListener('click', (event) => {
-      event.stopPropagation();
-      onboardingMenu.classList.toggle('open');
-      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
-    });
-
-    document.addEventListener('click', (event) => {
-      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
-        onboardingMenu.classList.remove('open');
-        onboardingToggle.setAttribute('aria-expanded', 'false');
-      }
-    });
-
     (function enhancePasswordInputs() {
       const showLabel = '{{ t('password.toggle.show') }}';
       const hideLabel = '{{ t('password.toggle.hide') }}';
@@ -276,5 +64,4 @@
       });
     })();
   </script>
-</body>
-</html>
+{% endblock %}

--- a/d2ha/templates/setup_2fa.html
+++ b/d2ha/templates/setup_2fa.html
@@ -1,227 +1,37 @@
-<!DOCTYPE html>
-<html lang="{{ get_current_lang() }}">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>D2HA – Configura 2FA</title>
-  <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
-      --accent-2: #7cffc3;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(49,196,255,0.35);
-      --accent-glow-soft: rgba(49,196,255,0.25);
-      --accent-border-strong: rgba(49,196,255,0.55);
-      --accent-border: rgba(49,196,255,0.45);
-      --accent-border-soft: rgba(49,196,255,0.3);
-      --accent-surface: rgba(49,196,255,0.08);
-      --text: #e7ecf4;
-      --muted: #9aa7bd;
-      --border: rgba(255,255,255,0.08);
-      --shadow: 0 10px 30px rgba(0,0,0,0.45);
-      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
-      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
-      --control-surface: #0f141f;
-    }
+{% extends "layouts/auth_base.html" %}
+{% block title %}D2HA – Configura 2FA{% endblock %}
 
-    body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
-      --accent-2: #fb923c;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
-      --accent-glow-soft: rgba(249,115,22,0.18);
-      --accent-border-strong: rgba(249,115,22,0.55);
-      --accent-border: rgba(249,115,22,0.42);
-      --accent-border-soft: rgba(249,115,22,0.26);
-      --accent-surface: rgba(249,115,22,0.08);
-      --text: #1f2937;
-      --muted: #4b5563;
-      --border: rgba(0,0,0,0.08);
-      --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
-      --control-surface: #fffaf3;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
-                  var(--bg);
-      color: var(--text);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 18px;
-    }
-    .card {
-      width: min(520px, 100%);
-      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 20px 22px;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-toolbar {
-      position: fixed;
-      top: 12px;
-      right: 12px;
-      z-index: 20;
-      display: flex;
-      justify-content: flex-end;
-      width: 100%;
-      pointer-events: none;
-      padding: 0 8px;
-    }
-    .onboarding-toggle {
-      pointer-events: auto;
-      background: var(--panel);
-      color: var(--text);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 10px 12px;
-      font-size: 1rem;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-menu {
-      position: absolute;
-      top: 52px;
-      right: 14px;
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      box-shadow: var(--shadow);
-      padding: 12px;
-      min-width: 240px;
-      display: none;
-      pointer-events: auto;
-    }
-    .onboarding-menu.open { display: block; }
-    .onboarding-menu h2 {
-      margin: 0 0 10px;
-      font-size: 0.95rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-    .onboarding-menu form {
-      margin: 0 0 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
-    .onboarding-menu select {
-      width: 100%;
-      padding: 8px 10px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: var(--panel-2);
-      color: var(--text);
-      font-size: 0.95rem;
-    }
-    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
-    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
-    .secret-box { background: var(--panel-2); border:1px solid var(--border); border-radius: 12px; padding: 12px; font-family: "JetBrains Mono", monospace; margin: 8px 0; }
-    .actions { display: flex; gap: 12px; flex-wrap: wrap; }
-    .btn { padding: 12px 16px; border-radius: 12px; border: none; font-weight: 800; cursor: pointer; }
-    .btn-primary { background: var(--accent-gradient); color: #0c121e; box-shadow: 0 8px 18px var(--accent-glow); }
-    .btn-secondary { background: rgba(255,255,255,0.06); color: var(--text); border:1px solid var(--border); }
-    input[type="text"] { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
-    .layout { display: grid; grid-template-columns: 1fr 1.4fr; gap: 18px; align-items: flex-start; margin: 14px 0; }
-    .qr-box { background: var(--panel-2); border: 1px solid var(--border); border-radius: 12px; padding: 12px; text-align: center; box-shadow: var(--shadow); }
-    .qr-title { margin: 0 0 8px; font-weight: 800; letter-spacing: 0.06em; color: var(--muted); text-transform: uppercase; font-size: 0.85rem; }
-    .qr-image { width: 100%; max-width: 210px; height: auto; image-rendering: crisp-edges; border-radius: 10px; background: white; padding: 10px; }
-    .section-title { font-weight: 800; margin: 0 0 6px; letter-spacing: 0.04em; }
-    @media (max-width: 720px) { .layout { grid-template-columns: 1fr; } .qr-box { justify-self: center; width: 100%; max-width: 320px; } }
-  </style>
-</head>
-<body class="theme-{{ get_current_theme() }}">
-  <div class="onboarding-toolbar">
-    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
-    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
-      <h2>{{ t('settings.title') }}</h2>
-      <form method="post" action="{{ url_for('set_language') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-lang">{{ t('language.label') }}</label>
-        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
-          {% for lang_code in SUPPORTED_LANGS %}
-          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
-            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
-          </option>
-          {% endfor %}
-        </select>
-      </form>
-      <form method="post" action="{{ url_for('set_theme') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-theme">{{ t('theme.label') }}</label>
-        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
-          {% for theme in SUPPORTED_THEMES %}
-          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
-          {% endfor %}
-        </select>
-      </form>
+{% block auth_content %}
+  <h1>{{ t('setup_2fa.title') }}</h1>
+  <p>{{ t('setup_2fa.intro') }}</p>
+  <p>{{ t('setup_2fa.hint') }}</p>
+
+  {% include 'partials/flash_messages.html' %}
+
+  <div class="note">
+    <p>{{ t('setup_2fa.step1') }}</p>
+    <p>{{ t('setup_2fa.step2') }}</p>
+    <p>{{ t('setup_2fa.step3') }}</p>
+  </div>
+
+  <div class="layout">
+    <div class="qr-box">
+      <p class="qr-title">{{ t('setup_2fa.qr_title') }}</p>
+      <img class="qr-image" src="{{ qr_code_data_uri }}" alt="QR code" loading="lazy" />
+    </div>
+    <div>
+      <p class="section-title">{{ t('setup_2fa.secret') }}</p>
+      <div class="secret-box">{{ secret }}</div>
+      <p class="muted" style="color: var(--muted); word-break: break-all;">{{ t('setup_2fa.uri').format(uri=provisioning_uri) }}</p>
     </div>
   </div>
-  <div class="card">
-    <h1>{{ t('setup_2fa.title') }}</h1>
-    <p>{{ t('setup_2fa.intro') }}</p>
-    <p>{{ t('setup_2fa.hint') }}</p>
 
-    {% include 'partials/flash_messages.html' %}
-
-    <div class="note">
-      <p>{{ t('setup_2fa.step1') }}</p>
-      <p>{{ t('setup_2fa.step2') }}</p>
-      <p>{{ t('setup_2fa.step3') }}</p>
+  <form method="post" autocomplete="off" class="auth-actions-form">
+    <label for="token">{{ t('setup_2fa.token_label') }}</label>
+    <input type="text" id="token" name="token" pattern="\d{6}" inputmode="numeric" autocomplete="one-time-code" />
+    <div class="actions">
+      <button class="btn btn-primary" type="submit" name="choice" value="enable">{{ t('setup_2fa.enable') }}</button>
+      <button class="btn btn-secondary" type="submit" name="choice" value="skip">{{ t('setup_2fa.skip') }}</button>
     </div>
-
-    <div class="layout">
-      <div class="qr-box">
-        <p class="qr-title">{{ t('setup_2fa.qr_title') }}</p>
-        <img class="qr-image" src="{{ qr_code_data_uri }}" alt="QR code" loading="lazy" />
-      </div>
-      <div>
-        <p class="section-title">{{ t('setup_2fa.secret') }}</p>
-        <div class="secret-box">{{ secret }}</div>
-        <p class="muted" style="color: var(--muted); word-break: break-all;">{{ t('setup_2fa.uri').format(uri=provisioning_uri) }}</p>
-      </div>
-    </div>
-
-    <form method="post" autocomplete="off" style="margin-top:12px; display:flex; flex-direction:column; gap:10px;">
-      <label for="token">{{ t('setup_2fa.token_label') }}</label>
-      <input type="text" id="token" name="token" pattern="\d{6}" inputmode="numeric" autocomplete="one-time-code" />
-      <div class="actions">
-        <button class="btn btn-primary" type="submit" name="choice" value="enable">{{ t('setup_2fa.enable') }}</button>
-        <button class="btn btn-secondary" type="submit" name="choice" value="skip">{{ t('setup_2fa.skip') }}</button>
-      </div>
-    </form>
-  </div>
-  <script>
-    const onboardingToggle = document.getElementById('onboardingToggle');
-    const onboardingMenu = document.getElementById('onboardingMenu');
-
-    onboardingToggle.addEventListener('click', (event) => {
-      event.stopPropagation();
-      onboardingMenu.classList.toggle('open');
-      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
-    });
-
-    document.addEventListener('click', (event) => {
-      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
-        onboardingMenu.classList.remove('open');
-        onboardingToggle.setAttribute('aria-expanded', 'false');
-      }
-    });
-  </script>
-</body>
-</html>
+  </form>
+{% endblock %}

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -1,244 +1,45 @@
-<!DOCTYPE html>
-<html lang="{{ get_current_lang() }}">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>D2HA – Primo accesso</title>
-  <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
-      --accent-2: #7cffc3;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(49,196,255,0.35);
-      --accent-glow-soft: rgba(49,196,255,0.25);
-      --accent-border-strong: rgba(49,196,255,0.55);
-      --accent-border: rgba(49,196,255,0.45);
-      --accent-border-soft: rgba(49,196,255,0.3);
-      --accent-surface: rgba(49,196,255,0.08);
-      --text: #e7ecf4;
-      --muted: #9aa7bd;
-      --border: rgba(255,255,255,0.08);
-      --shadow: 0 10px 30px rgba(0,0,0,0.45);
-      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
-      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
-      --control-surface: #0f141f;
-    }
+{% extends "layouts/auth_base.html" %}
+{% block title %}D2HA – Primo accesso{% endblock %}
 
-    body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
-      --accent-2: #fb923c;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
-      --accent-glow-soft: rgba(249,115,22,0.18);
-      --accent-border-strong: rgba(249,115,22,0.55);
-      --accent-border: rgba(249,115,22,0.42);
-      --accent-border-soft: rgba(249,115,22,0.26);
-      --accent-surface: rgba(249,115,22,0.08);
-      --text: #1f2937;
-      --muted: #4b5563;
-      --border: rgba(0,0,0,0.08);
-      --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
-      --control-surface: #fffaf3;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
-                  var(--bg);
-      color: var(--text);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 18px;
-    }
-    .card {
-      width: min(520px, 100%);
-      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 20px 22px;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-toolbar {
-      position: fixed;
-      top: 12px;
-      right: 12px;
-      z-index: 20;
-      display: flex;
-      justify-content: flex-end;
-      width: 100%;
-      pointer-events: none;
-      padding: 0 8px;
-    }
-    .onboarding-toggle {
-      pointer-events: auto;
-      background: var(--panel);
-      color: var(--text);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 10px 12px;
-      font-size: 1rem;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-menu {
-      position: absolute;
-      top: 52px;
-      right: 14px;
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      box-shadow: var(--shadow);
-      padding: 12px;
-      min-width: 240px;
-      display: none;
-      pointer-events: auto;
-    }
-    .onboarding-menu.open { display: block; }
-    .onboarding-menu h2 {
-      margin: 0 0 10px;
-      font-size: 0.95rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-    .onboarding-menu form {
-      margin: 0 0 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
-    .onboarding-menu select {
-      width: 100%;
-      padding: 8px 10px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: var(--panel-2);
-      color: var(--text);
-      font-size: 0.95rem;
-    }
-    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
-    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
-    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
-    label { font-weight: 700; color: var(--text); font-size: 0.9rem; }
-    input { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid var(--border); background: var(--panel-2); color: var(--text); font-size: 1rem; }
-    .password-input-wrapper { position: relative; display: flex; align-items: center; }
-    .password-input-wrapper input { padding-right: 42px; }
-    .password-toggle {
-      position: absolute;
-      right: 10px;
-      background: transparent;
-      border: none;
-      color: var(--muted);
-      cursor: pointer;
-      opacity: 0.75;
-      transition: opacity 0.15s ease;
-      font-size: 1rem;
-      line-height: 1;
-      padding: 4px;
-    }
-    .password-toggle:hover { opacity: 1; }
-    .btn { margin-top: 6px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: 0 8px 18px var(--accent-glow); }
-    .btn:hover { filter: brightness(1.05); }
-    ul { margin: 0 0 10px 20px; color: var(--muted); }
-    .password-hint { margin-top: 6px; font-size: 0.9rem; color: var(--muted); }
-    .strength-weak { color: #f87171; }
-    .strength-medium { color: #fbbf24; }
-    .strength-strong { color: #7cffc3; }
-  </style>
-</head>
-<body class="theme-{{ get_current_theme() }}">
-  <div class="onboarding-toolbar">
-    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
-    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
-      <h2>{{ t('settings.title') }}</h2>
-      <form method="post" action="{{ url_for('set_language') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-lang">{{ t('language.label') }}</label>
-        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
-          {% for lang_code in SUPPORTED_LANGS %}
-          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
-            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
-          </option>
-          {% endfor %}
-        </select>
-      </form>
-      <form method="post" action="{{ url_for('set_theme') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-theme">{{ t('theme.label') }}</label>
-        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
-          {% for theme in SUPPORTED_THEMES %}
-          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
-          {% endfor %}
-        </select>
-      </form>
+{% block auth_content %}
+  <h1>{{ t('setup_account.heading') }}</h1>
+  <p>{{ t('setup_account.intro')|safe }}</p>
+  <p>{{ t('setup_account.tips_title') }}</p>
+  <ul>
+    <li>{{ t('setup_account.tip_length') }}</li>
+    <li>{{ t('setup_account.tip_unique') }}</li>
+    <li>{{ t('setup_account.tip_username').format(current_username=current_username) }}</li>
+  </ul>
+
+  {% include 'partials/flash_messages.html' %}
+
+  <form method="post" autocomplete="off">
+    <div>
+      <label for="new_username">{{ t('setup_account.new_username') }}</label>
+      <input type="text" id="new_username" name="new_username" placeholder="{{ current_username }}" />
     </div>
-  </div>
-  <div class="card">
-    <h1>{{ t('setup_account.heading') }}</h1>
-    <p>{{ t('setup_account.intro')|safe }}</p>
-    <p>{{ t('setup_account.tips_title') }}</p>
-    <ul>
-      <li>{{ t('setup_account.tip_length') }}</li>
-      <li>{{ t('setup_account.tip_unique') }}</li>
-      <li>{{ t('setup_account.tip_username').format(current_username=current_username) }}</li>
-    </ul>
+    <div>
+      <label for="new_password">{{ t('setup_account.new_password') }}</label>
+      <div class="password-input-wrapper">
+        <input type="password" id="new_password" name="new_password" required />
+        <button type="button" class="password-toggle" aria-label="{{ t('password.toggle.show') }}" title="{{ t('password.toggle.show') }}">👁</button>
+      </div>
+      <div id="passwordStrength" class="password-hint" aria-live="polite"></div>
+    </div>
+    <div>
+      <label for="new_password_confirm">{{ t('setup_account.confirm_password') }}</label>
+      <div class="password-input-wrapper">
+        <input type="password" id="new_password_confirm" name="new_password_confirm" required />
+        <button type="button" class="password-toggle" aria-label="{{ t('password.toggle.show') }}" title="{{ t('password.toggle.show') }}">👁</button>
+      </div>
+      <div id="passwordMatch" class="password-hint" aria-live="polite"></div>
+    </div>
+    <button type="submit" class="btn">{{ t('setup_account.submit') }}</button>
+  </form>
+{% endblock %}
 
-    {% include 'partials/flash_messages.html' %}
-
-    <form method="post" autocomplete="off">
-      <div>
-        <label for="new_username">{{ t('setup_account.new_username') }}</label>
-        <input type="text" id="new_username" name="new_username" placeholder="{{ current_username }}" />
-      </div>
-      <div>
-        <label for="new_password">{{ t('setup_account.new_password') }}</label>
-        <div class="password-input-wrapper">
-          <input type="password" id="new_password" name="new_password" required />
-          <button type="button" class="password-toggle" aria-label="{{ t('password.toggle.show') }}" title="{{ t('password.toggle.show') }}">👁</button>
-        </div>
-        <div id="passwordStrength" class="password-hint" aria-live="polite"></div>
-      </div>
-      <div>
-        <label for="new_password_confirm">{{ t('setup_account.confirm_password') }}</label>
-        <div class="password-input-wrapper">
-          <input type="password" id="new_password_confirm" name="new_password_confirm" required />
-          <button type="button" class="password-toggle" aria-label="{{ t('password.toggle.show') }}" title="{{ t('password.toggle.show') }}">👁</button>
-        </div>
-        <div id="passwordMatch" class="password-hint" aria-live="polite"></div>
-      </div>
-      <button type="submit" class="btn">{{ t('setup_account.submit') }}</button>
-    </form>
-  </div>
+{% block auth_scripts %}
   <script>
-    const onboardingToggle = document.getElementById('onboardingToggle');
-    const onboardingMenu = document.getElementById('onboardingMenu');
-
-    onboardingToggle.addEventListener('click', (event) => {
-      event.stopPropagation();
-      onboardingMenu.classList.toggle('open');
-      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
-    });
-
-    document.addEventListener('click', (event) => {
-      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
-        onboardingMenu.classList.remove('open');
-        onboardingToggle.setAttribute('aria-expanded', 'false');
-      }
-    });
-
     const strengthLabel = document.getElementById('passwordStrength');
     const matchLabel = document.getElementById('passwordMatch');
     const passwordInput = document.getElementById('new_password');
@@ -284,10 +85,10 @@
     function evaluateStrength(password) {
       if (!password) return null;
       let score = 0;
-      if (password.length >= 10) score++;
-      if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score++;
-      if (/\d/.test(password)) score++;
-      if (/[^A-Za-z0-9]/.test(password)) score++;
+      if (password.length >= 10) score += 1;
+      if (/[A-Z]/.test(password) && /[a-z]/.test(password)) score += 1;
+      if (/\d/.test(password)) score += 1;
+      if (/[^A-Za-z0-9]/.test(password)) score += 1;
 
       if (score >= 3) return 'strong';
       if (score === 2) return 'medium';
@@ -330,5 +131,4 @@
     });
     confirmInput.addEventListener('input', updateMatch);
   </script>
-</body>
-</html>
+{% endblock %}

--- a/d2ha/templates/setup_autodiscovery.html
+++ b/d2ha/templates/setup_autodiscovery.html
@@ -1,211 +1,26 @@
-<!DOCTYPE html>
-<html lang="{{ get_current_lang() }}">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>D2HA – Autodiscovery MQTT</title>
-  <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
-      --accent-2: #7cffc3;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(49,196,255,0.35);
-      --accent-glow-soft: rgba(49,196,255,0.25);
-      --accent-border-strong: rgba(49,196,255,0.55);
-      --accent-border: rgba(49,196,255,0.45);
-      --accent-border-soft: rgba(49,196,255,0.3);
-      --accent-surface: rgba(49,196,255,0.08);
-      --text: #e7ecf4;
-      --muted: #9aa7bd;
-      --border: rgba(255,255,255,0.08);
-      --shadow: 0 10px 30px rgba(0,0,0,0.45);
-      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
-      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
-      --control-surface: #0f141f;
-    }
+{% extends "layouts/auth_base.html" %}
+{% block title %}D2HA – Autodiscovery MQTT{% endblock %}
 
-    body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
-      --accent-2: #fb923c;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
-      --accent-glow-soft: rgba(249,115,22,0.18);
-      --accent-border-strong: rgba(249,115,22,0.55);
-      --accent-border: rgba(249,115,22,0.42);
-      --accent-border-soft: rgba(249,115,22,0.26);
-      --accent-surface: rgba(249,115,22,0.08);
-      --text: #1f2937;
-      --muted: #4b5563;
-      --border: rgba(0,0,0,0.08);
-      --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
-      --control-surface: #fffaf3;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
-                  var(--bg);
-      color: var(--text);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 18px;
-    }
-    .card {
-      width: min(520px, 100%);
-      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 20px 22px;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-toolbar {
-      position: fixed;
-      top: 12px;
-      right: 12px;
-      z-index: 20;
-      display: flex;
-      justify-content: flex-end;
-      width: 100%;
-      pointer-events: none;
-      padding: 0 8px;
-    }
-    .onboarding-toggle {
-      pointer-events: auto;
-      background: var(--panel);
-      color: var(--text);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 10px 12px;
-      font-size: 1rem;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-menu {
-      position: absolute;
-      top: 52px;
-      right: 14px;
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      box-shadow: var(--shadow);
-      padding: 12px;
-      min-width: 240px;
-      display: none;
-      pointer-events: auto;
-    }
-    .onboarding-menu.open { display: block; }
-    .onboarding-menu h2 {
-      margin: 0 0 10px;
-      font-size: 0.95rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-    .onboarding-menu form {
-      margin: 0 0 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
-    .onboarding-menu select {
-      width: 100%;
-      padding: 8px 10px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: var(--panel-2);
-      color: var(--text);
-      font-size: 0.95rem;
-    }
-    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
-    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
-    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
-    label { font-weight: 700; color: var(--text); font-size: 0.95rem; display:block; }
-    input[type="radio"] { width: 18px; height: 18px; accent-color: var(--accent); }
-    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
-    button:hover { filter: brightness(1.05); }
-    .hint { font-size: 0.85rem; opacity: 0.8; }
-  </style>
-</head>
-<body class="theme-{{ get_current_theme() }}">
-  <div class="onboarding-toolbar">
-    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
-    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
-      <h2>{{ t('settings.title') }}</h2>
-      <form method="post" action="{{ url_for('set_language') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-lang">{{ t('language.label') }}</label>
-        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
-          {% for lang_code in SUPPORTED_LANGS %}
-          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
-            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
-          </option>
-          {% endfor %}
-        </select>
-      </form>
-      <form method="post" action="{{ url_for('set_theme') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-theme">{{ t('theme.label') }}</label>
-        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
-          {% for theme in SUPPORTED_THEMES %}
-          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
-          {% endfor %}
-        </select>
-      </form>
-    </div>
-  </div>
-  <div class="card">
-    <h1>{{ t('setup_autodiscovery.heading') }}</h1>
-    <p>{{ t('setup_autodiscovery.intro') }}</p>
-    <p>{{ t('setup_autodiscovery.hint') }}</p>
+{% block auth_content %}
+  <h1>{{ t('setup_autodiscovery.heading') }}</h1>
+  <p>{{ t('setup_autodiscovery.intro') }}</p>
+  <p>{{ t('setup_autodiscovery.hint') }}</p>
 
-    {% include 'partials/flash_messages.html' %}
+  {% include 'partials/flash_messages.html' %}
 
-    <form method="post">
-      <label style="margin-bottom:8px;">
-        <input type="radio" name="autodiscovery_choice" value="enable_all" {% if mqtt_default_entities_enabled %}checked{% endif %}>
-        <strong>{{ t('setup_autodiscovery.enable_all_long') }}</strong><br>
-        <span class="hint">{{ t('setup_autodiscovery.enable_all_hint') }}</span>
-      </label>
+  <form method="post">
+    <label class="auth-choice">
+      <input type="radio" name="autodiscovery_choice" value="enable_all" {% if mqtt_default_entities_enabled %}checked{% endif %}>
+      <strong>{{ t('setup_autodiscovery.enable_all_long') }}</strong>
+      <span class="hint">{{ t('setup_autodiscovery.enable_all_hint') }}</span>
+    </label>
 
-      <label style="margin-top:8px;">
-        <input type="radio" name="autodiscovery_choice" value="disable_all" {% if not mqtt_default_entities_enabled %}checked{% endif %}>
-        <strong>{{ t('setup_autodiscovery.disable_all_long') }}</strong><br>
-        <span class="hint">{{ t('setup_autodiscovery.disable_all_hint') }}</span>
-      </label>
+    <label class="auth-choice">
+      <input type="radio" name="autodiscovery_choice" value="disable_all" {% if not mqtt_default_entities_enabled %}checked{% endif %}>
+      <strong>{{ t('setup_autodiscovery.disable_all_long') }}</strong>
+      <span class="hint">{{ t('setup_autodiscovery.disable_all_hint') }}</span>
+    </label>
 
-      <button type="submit" style="margin-top:16px;">{{ t('setup_autodiscovery.submit') }}</button>
-    </form>
-
-  </div>
-  <script>
-    const onboardingToggle = document.getElementById('onboardingToggle');
-    const onboardingMenu = document.getElementById('onboardingMenu');
-
-    onboardingToggle.addEventListener('click', (event) => {
-      event.stopPropagation();
-      onboardingMenu.classList.toggle('open');
-      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
-    });
-
-    document.addEventListener('click', (event) => {
-      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
-        onboardingMenu.classList.remove('open');
-        onboardingToggle.setAttribute('aria-expanded', 'false');
-      }
-    });
-  </script>
-</body>
-</html>
+    <button type="submit" style="margin-top:16px;">{{ t('setup_autodiscovery.submit') }}</button>
+  </form>
+{% endblock %}

--- a/d2ha/templates/setup_modes.html
+++ b/d2ha/templates/setup_modes.html
@@ -1,209 +1,30 @@
-<!DOCTYPE html>
-<html lang="{{ get_current_lang() }}">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>D2HA – Modalità del sistema</title>
-  <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
-      --accent-2: #7cffc3;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(49,196,255,0.35);
-      --accent-glow-soft: rgba(49,196,255,0.25);
-      --accent-border-strong: rgba(49,196,255,0.55);
-      --accent-border: rgba(49,196,255,0.45);
-      --accent-border-soft: rgba(49,196,255,0.3);
-      --accent-surface: rgba(49,196,255,0.08);
-      --text: #e7ecf4;
-      --muted: #9aa7bd;
-      --border: rgba(255,255,255,0.08);
-      --shadow: 0 10px 30px rgba(0,0,0,0.45);
-      --header-bg: linear-gradient(90deg, #0d111c, #12182a);
-      --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
-      --control-surface: #0f141f;
-    }
+{% extends "layouts/auth_base.html" %}
+{% block title %}D2HA – Modalità del sistema{% endblock %}
 
-    body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
-      --accent-2: #fb923c;
-      --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
-      --accent-glow-soft: rgba(249,115,22,0.18);
-      --accent-border-strong: rgba(249,115,22,0.55);
-      --accent-border: rgba(249,115,22,0.42);
-      --accent-border-soft: rgba(249,115,22,0.26);
-      --accent-surface: rgba(249,115,22,0.08);
-      --text: #1f2937;
-      --muted: #4b5563;
-      --border: rgba(0,0,0,0.08);
-      --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
-      --control-surface: #fffaf3;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 15% 15%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 80% 10%, rgba(124,255,195,0.06), transparent 22%),
-                  var(--bg);
-      color: var(--text);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding: 18px;
-    }
-    .card {
-      width: min(520px, 100%);
-      background: linear-gradient(180deg, var(--accent-surface), rgba(124,255,195,0.04)), var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 16px;
-      padding: 20px 22px;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-toolbar {
-      position: fixed;
-      top: 12px;
-      right: 12px;
-      z-index: 20;
-      display: flex;
-      justify-content: flex-end;
-      width: 100%;
-      pointer-events: none;
-      padding: 0 8px;
-    }
-    .onboarding-toggle {
-      pointer-events: auto;
-      background: var(--panel);
-      color: var(--text);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      padding: 10px 12px;
-      font-size: 1rem;
-      cursor: pointer;
-      box-shadow: var(--shadow);
-    }
-    .onboarding-menu {
-      position: absolute;
-      top: 52px;
-      right: 14px;
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      box-shadow: var(--shadow);
-      padding: 12px;
-      min-width: 240px;
-      display: none;
-      pointer-events: auto;
-    }
-    .onboarding-menu.open { display: block; }
-    .onboarding-menu h2 {
-      margin: 0 0 10px;
-      font-size: 0.95rem;
-      letter-spacing: 0.06em;
-      text-transform: uppercase;
-    }
-    .onboarding-menu form {
-      margin: 0 0 10px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .onboarding-menu label { font-weight: 700; font-size: 0.85rem; color: var(--muted); }
-    .onboarding-menu select {
-      width: 100%;
-      padding: 8px 10px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: var(--panel-2);
-      color: var(--text);
-      font-size: 0.95rem;
-    }
-    h1 { margin: 0 0 6px; letter-spacing: 0.08em; text-transform: uppercase; font-size: 1.1rem; }
-    p { margin: 0 0 12px; color: var(--muted); line-height: 1.5; }
-    .pill { display: inline-block; padding: 6px 10px; border-radius: 999px; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); font-weight: 800; letter-spacing: 0.05em; }
-    form { display: flex; flex-direction: column; gap: 12px; margin-top: 14px; }
-    label { font-weight: 700; color: var(--text); font-size: 0.95rem; }
-    input[type="checkbox"] { width: 18px; height: 18px; accent-color: var(--accent); }
-    button { margin-top: 10px; padding: 12px; border: none; border-radius: 12px; background: var(--accent-gradient); color: #0c121e; font-weight: 800; cursor: pointer; box-shadow: var(--shadow); }
-    button:hover { filter: brightness(1.05); }
-    .hint { font-size: 0.85rem; opacity: 0.8; margin-top: -6px; }
-  </style>
-</head>
-<body class="theme-{{ get_current_theme() }}">
-  <div class="onboarding-toolbar">
-    <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
-    <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">
-      <h2>{{ t('settings.title') }}</h2>
-      <form method="post" action="{{ url_for('set_language') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-lang">{{ t('language.label') }}</label>
-        <select id="onboarding-lang" name="lang" onchange="this.form.submit()">
-          {% for lang_code in SUPPORTED_LANGS %}
-          <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
-            {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
-          </option>
-          {% endfor %}
-        </select>
-      </form>
-      <form method="post" action="{{ url_for('set_theme') }}">
-        <input type="hidden" name="next" value="{{ request.path }}">
-        <label for="onboarding-theme">{{ t('theme.label') }}</label>
-        <select id="onboarding-theme" name="theme" onchange="this.form.submit()">
-          {% for theme in SUPPORTED_THEMES %}
-          <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>{{ t('theme.' + theme) }}</option>
-          {% endfor %}
-        </select>
-      </form>
-    </div>
-  </div>
-  <div class="card">
-    <h1>{{ t('setup_modes.heading') }}</h1>
-    <p>{{ t('setup_modes.description') }}</p>
+{% block auth_content %}
+  <h1>{{ t('setup_modes.heading') }}</h1>
+  <p>{{ t('setup_modes.description') }}</p>
 
-    {% include 'partials/flash_messages.html' %}
+  {% include 'partials/flash_messages.html' %}
 
-    <form method="post">
-      <label style="display:flex;align-items:center;gap:8px;">
-        <input type="checkbox" name="safe_mode_enabled" {% if safe_mode_enabled %}checked{% endif %}>
-        <span><strong>{{ t('setup_modes.safe') }}</strong> ({{ t('setup_modes.safe_note') }})</span>
-      </label>
-      <p class="hint">{{ t('setup_modes.safe_hint') }}</p>
+  <form method="post">
+    <label class="auth-choice" style="display:flex;align-items:flex-start;gap:10px;">
+      <input type="checkbox" name="safe_mode_enabled" {% if safe_mode_enabled %}checked{% endif %}>
+      <div>
+        <strong>{{ t('setup_modes.safe') }}</strong>
+        <span class="hint">{{ t('setup_modes.safe_note') }}</span>
+      </div>
+    </label>
+    <p class="hint">{{ t('setup_modes.safe_hint') }}</p>
 
-      <label style="display:flex;align-items:center;gap:8px;margin-top:12px;">
-        <input type="checkbox" name="performance_mode_enabled" {% if performance_mode_enabled %}checked{% endif %}>
-        <span><strong>{{ t('setup_modes.performance') }}</strong></span>
-      </label>
-      <p class="hint">{{ t('setup_modes.performance_hint') }}</p>
+    <label class="auth-choice" style="display:flex;align-items:flex-start;gap:10px;">
+      <input type="checkbox" name="performance_mode_enabled" {% if performance_mode_enabled %}checked{% endif %}>
+      <div>
+        <strong>{{ t('setup_modes.performance') }}</strong>
+        <span class="hint">{{ t('setup_modes.performance_hint') }}</span>
+      </div>
+    </label>
 
-      <button type="submit">{{ t('setup_modes.submit') }}</button>
-    </form>
-  </div>
-  <script>
-    const onboardingToggle = document.getElementById('onboardingToggle');
-    const onboardingMenu = document.getElementById('onboardingMenu');
-
-    onboardingToggle.addEventListener('click', (event) => {
-      event.stopPropagation();
-      onboardingMenu.classList.toggle('open');
-      onboardingToggle.setAttribute('aria-expanded', onboardingMenu.classList.contains('open'));
-    });
-
-    document.addEventListener('click', (event) => {
-      if (!onboardingMenu.contains(event.target) && event.target !== onboardingToggle) {
-        onboardingMenu.classList.remove('open');
-        onboardingToggle.setAttribute('aria-expanded', 'false');
-      }
-    });
-  </script>
-</body>
-</html>
+    <button type="submit">{{ t('setup_modes.submit') }}</button>
+  </form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable auth layout with title, logo, and onboarding toolbar shared by login and wizard screens
- implement themed glassmorphism styling and animated canvas background with reusable CSS and JS assets
- update login and onboarding templates to use the new structure and canvas-driven background

## Testing
- python -m compileall d2ha


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234b84112c832d9502f4bbe7eaa768)