### PR TITLE
Fix password toggle behaviour and reposition flash notifications

### DIFF
--- a/d2ha/static/css/auth.css
+++ b/d2ha/static/css/auth.css
@@ -231,16 +231,23 @@ body {
 
 .password-toggle {
   position: absolute;
+  top: 50%;
   right: 10px;
+  transform: translateY(-50%);
   background: transparent;
   border: none;
   color: var(--muted);
   cursor: pointer;
   opacity: 0.8;
   transition: opacity 0.15s ease;
-  font-size: 1rem;
+  font-size: 0.95rem;
   line-height: 1;
-  padding: 4px;
+  padding: 6px;
+  height: 32px;
+  width: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .password-toggle:hover {

--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -39,28 +39,40 @@
       const hideLabel = '{{ t('password.toggle.hide') }}';
 
       document.querySelectorAll('input[type="password"]').forEach((input) => {
-        if (input.closest('.password-input-wrapper')) return;
+        const existingWrapper = input.closest('.password-input-wrapper');
+        const wrapper = existingWrapper || (() => {
+          const created = document.createElement('div');
+          created.className = 'password-input-wrapper';
+          input.parentNode.insertBefore(created, input);
+          created.appendChild(input);
+          return created;
+        })();
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'password-input-wrapper';
-        input.parentNode.insertBefore(wrapper, input);
-        wrapper.appendChild(input);
+        let toggle = wrapper.querySelector('.password-toggle');
+        if (!toggle) {
+          toggle = document.createElement('button');
+          toggle.type = 'button';
+          toggle.className = 'password-toggle';
+          wrapper.appendChild(toggle);
+        }
 
-        const toggle = document.createElement('button');
-        toggle.type = 'button';
-        toggle.className = 'password-toggle';
-        toggle.setAttribute('aria-label', showLabel);
-        toggle.title = showLabel;
-        toggle.textContent = '👁';
+        if (toggle.dataset.bound === 'true') return;
+
+        const updateState = (isHidden) => {
+          toggle.setAttribute('aria-label', isHidden ? showLabel : hideLabel);
+          toggle.title = isHidden ? showLabel : hideLabel;
+          toggle.textContent = isHidden ? '👁' : '🙈';
+        };
+
+        updateState(true);
+
         toggle.addEventListener('click', () => {
           const isHidden = input.type === 'password';
           input.type = isHidden ? 'text' : 'password';
-          toggle.setAttribute('aria-label', isHidden ? hideLabel : showLabel);
-          toggle.title = isHidden ? hideLabel : showLabel;
-          toggle.textContent = isHidden ? '🙈' : '👁';
+          updateState(!isHidden);
         });
 
-        wrapper.appendChild(toggle);
+        toggle.dataset.bound = 'true';
       });
     })();
   </script>

--- a/d2ha/templates/partials/flash_messages.html
+++ b/d2ha/templates/partials/flash_messages.html
@@ -3,7 +3,7 @@
     <style>
       .flash-toast-container {
         position: fixed;
-        top: 14px;
+        top: 88px;
         left: 0;
         right: 0;
         display: flex;

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -363,28 +363,40 @@
       const hideLabel = '{{ t('password.toggle.hide') }}';
 
       document.querySelectorAll('input[type="password"]').forEach((input) => {
-        if (input.closest('.password-input-wrapper')) return;
+        const existingWrapper = input.closest('.password-input-wrapper');
+        const wrapper = existingWrapper || (() => {
+          const created = document.createElement('div');
+          created.className = 'password-input-wrapper';
+          input.parentNode.insertBefore(created, input);
+          created.appendChild(input);
+          return created;
+        })();
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'password-input-wrapper';
-        input.parentNode.insertBefore(wrapper, input);
-        wrapper.appendChild(input);
+        let toggle = wrapper.querySelector('.password-toggle');
+        if (!toggle) {
+          toggle = document.createElement('button');
+          toggle.type = 'button';
+          toggle.className = 'password-toggle';
+          wrapper.appendChild(toggle);
+        }
 
-        const toggle = document.createElement('button');
-        toggle.type = 'button';
-        toggle.className = 'password-toggle';
-        toggle.setAttribute('aria-label', showLabel);
-        toggle.title = showLabel;
-        toggle.textContent = '👁';
+        if (toggle.dataset.bound === 'true') return;
+
+        const updateState = (isHidden) => {
+          toggle.setAttribute('aria-label', isHidden ? showLabel : hideLabel);
+          toggle.title = isHidden ? showLabel : hideLabel;
+          toggle.textContent = isHidden ? '👁' : '🙈';
+        };
+
+        updateState(true);
+
         toggle.addEventListener('click', () => {
           const isHidden = input.type === 'password';
           input.type = isHidden ? 'text' : 'password';
-          toggle.setAttribute('aria-label', isHidden ? hideLabel : showLabel);
-          toggle.title = isHidden ? hideLabel : showLabel;
-          toggle.textContent = isHidden ? '🙈' : '👁';
+          updateState(!isHidden);
         });
 
-        wrapper.appendChild(toggle);
+        toggle.dataset.bound = 'true';
       });
     })();
   </script>

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -57,28 +57,40 @@
 
     function enhancePasswordInputs() {
       document.querySelectorAll('input[type="password"]').forEach((input) => {
-        if (input.closest('.password-input-wrapper')) return;
+        const existingWrapper = input.closest('.password-input-wrapper');
+        const wrapper = existingWrapper || (() => {
+          const created = document.createElement('div');
+          created.className = 'password-input-wrapper';
+          input.parentNode.insertBefore(created, input);
+          created.appendChild(input);
+          return created;
+        })();
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'password-input-wrapper';
-        input.parentNode.insertBefore(wrapper, input);
-        wrapper.appendChild(input);
+        let toggle = wrapper.querySelector('.password-toggle');
+        if (!toggle) {
+          toggle = document.createElement('button');
+          toggle.type = 'button';
+          toggle.className = 'password-toggle';
+          wrapper.appendChild(toggle);
+        }
 
-        const toggle = document.createElement('button');
-        toggle.type = 'button';
-        toggle.className = 'password-toggle';
-        toggle.setAttribute('aria-label', showLabel);
-        toggle.title = showLabel;
-        toggle.textContent = '👁';
+        if (toggle.dataset.bound === 'true') return;
+
+        const updateState = (isHidden) => {
+          toggle.setAttribute('aria-label', isHidden ? showLabel : hideLabel);
+          toggle.title = isHidden ? showLabel : hideLabel;
+          toggle.textContent = isHidden ? '👁' : '🙈';
+        };
+
+        updateState(true);
+
         toggle.addEventListener('click', () => {
           const isHidden = input.type === 'password';
           input.type = isHidden ? 'text' : 'password';
-          toggle.setAttribute('aria-label', isHidden ? hideLabel : showLabel);
-          toggle.title = isHidden ? hideLabel : showLabel;
-          toggle.textContent = isHidden ? '🙈' : '👁';
+          updateState(!isHidden);
         });
 
-        wrapper.appendChild(toggle);
+        toggle.dataset.bound = 'true';
       });
     }
 


### PR DESCRIPTION
## Summary
- ensure password toggle buttons are properly sized and wired to show or hide passwords on authentication-related pages
- reposition flash notifications beneath the D2HA title for better visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234f5b211c832da2e000f671921832)