### PR TITLE
Fix password toggle alignment on security settings page

### DIFF
--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -152,7 +152,9 @@
     .password-input-wrapper input { padding-right: 42px; }
     .password-toggle {
       position: absolute;
+      top: 50%;
       right: 10px;
+      transform: translateY(-50%);
       background: transparent;
       border: none;
       color: var(--muted);
@@ -162,6 +164,11 @@
       font-size: 1rem;
       line-height: 1;
       padding: 4px;
+      height: 32px;
+      width: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
     }
     .password-toggle:hover { opacity: 1; }
     input:focus { outline: 2px solid var(--accent-border); }


### PR DESCRIPTION
## Summary
- adjust password toggle positioning to stay centered within password fields on the security settings page

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692350c3d20c832d9d8da45ab0a4b54c)