### PR TITLE
Move auth flash messages above wizard cards

### DIFF
--- a/d2ha/templates/layouts/auth_base.html
+++ b/d2ha/templates/layouts/auth_base.html
@@ -16,6 +16,8 @@
     </div>
 
     <div class="auth-overlay">
+      {% include 'partials/flash_messages.html' %}
+
       <div class="onboarding-toolbar">
         <button id="onboardingToggle" class="onboarding-toggle" type="button" aria-expanded="false" aria-controls="onboardingMenu" title="{{ t('settings.title') }}">🌐</button>
         <div id="onboardingMenu" class="onboarding-menu" role="region" aria-label="{{ t('settings.title') }}">

--- a/d2ha/templates/login.html
+++ b/d2ha/templates/login.html
@@ -7,8 +7,6 @@
   <p>{{ t("login.onboarding_hint")|safe }}</p>
   {% endif %}
 
-  {% include 'partials/flash_messages.html' %}
-
   <form method="post" autocomplete="off">
     <div>
       <label for="username">{{ t("login.username") }}</label>

--- a/d2ha/templates/setup_2fa.html
+++ b/d2ha/templates/setup_2fa.html
@@ -6,8 +6,6 @@
   <p>{{ t('setup_2fa.intro') }}</p>
   <p>{{ t('setup_2fa.hint') }}</p>
 
-  {% include 'partials/flash_messages.html' %}
-
   <div class="note">
     <p>{{ t('setup_2fa.step1') }}</p>
     <p>{{ t('setup_2fa.step2') }}</p>

--- a/d2ha/templates/setup_account.html
+++ b/d2ha/templates/setup_account.html
@@ -11,8 +11,6 @@
     <li>{{ t('setup_account.tip_username').format(current_username=current_username) }}</li>
   </ul>
 
-  {% include 'partials/flash_messages.html' %}
-
   <form method="post" autocomplete="off">
     <div>
       <label for="new_username">{{ t('setup_account.new_username') }}</label>

--- a/d2ha/templates/setup_autodiscovery.html
+++ b/d2ha/templates/setup_autodiscovery.html
@@ -6,8 +6,6 @@
   <p>{{ t('setup_autodiscovery.intro') }}</p>
   <p>{{ t('setup_autodiscovery.hint') }}</p>
 
-  {% include 'partials/flash_messages.html' %}
-
   <form method="post">
     <label class="auth-choice">
       <input type="radio" name="autodiscovery_choice" value="enable_all" {% if mqtt_default_entities_enabled %}checked{% endif %}>

--- a/d2ha/templates/setup_modes.html
+++ b/d2ha/templates/setup_modes.html
@@ -5,8 +5,6 @@
   <h1>{{ t('setup_modes.heading') }}</h1>
   <p>{{ t('setup_modes.description') }}</p>
 
-  {% include 'partials/flash_messages.html' %}
-
   <form method="post">
     <label class="auth-choice" style="display:flex;align-items:flex-start;gap:10px;">
       <input type="checkbox" name="safe_mode_enabled" {% if safe_mode_enabled %}checked{% endif %}>


### PR DESCRIPTION
## Summary
- Render flash notifications from the auth layout so they appear above the wizard card instead of inside it
- Remove duplicate per-page flash includes from individual auth templates

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692355de9d8c832d985eddd4529df690)