### PR TITLE
Add shared d2ha theme stylesheet

### DIFF
--- a/d2ha/static/css/d2ha-theme.css
+++ b/d2ha/static/css/d2ha-theme.css
@@ -1,0 +1,318 @@
+/*
+ * d2ha theme foundation
+ * - Provides shared tokens and component styles for the application shell.
+ * - Mirrors the light/dark toggle behavior used by the auth flow: apply
+ *   `.theme-light` or `.theme-dark` on the <html>, <body>, or a wrapper element.
+ */
+:root {
+  /* Base palette */
+  --color-bg: #0f1629;
+  --color-surface: #151d32;
+  --color-surface-muted: #1b243b;
+  --color-surface-alt: #11182c;
+  --color-accent: #31c4ff;
+  --color-accent-2: #7cffc3;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-border-strong: rgba(49, 196, 255, 0.55);
+  --color-border-soft: rgba(49, 196, 255, 0.25);
+  --color-text: #e5ecf8;
+  --color-muted: #9eb0c9;
+  --color-disabled: rgba(158, 176, 201, 0.42);
+
+  /* State tokens */
+  --color-success: #35c48d;
+  --color-warn: #f4b22e;
+  --color-error: #ef476f;
+  --color-info: #4ea8ff;
+  --color-success-surface: rgba(53, 196, 141, 0.12);
+  --color-warn-surface: rgba(244, 178, 46, 0.14);
+  --color-error-surface: rgba(239, 71, 111, 0.14);
+  --color-info-surface: rgba(78, 168, 255, 0.12);
+
+  /* Glow / overlays */
+  --gradient-accent: linear-gradient(135deg, var(--color-accent), var(--color-accent-2));
+  --gradient-overlay: radial-gradient(circle at 14% 18%, rgba(49, 196, 255, 0.12), transparent 36%),
+    radial-gradient(circle at 84% 12%, rgba(124, 255, 195, 0.14), transparent 34%);
+  --overlay-veil: linear-gradient(180deg, rgba(8, 11, 20, 0.64), rgba(8, 11, 20, 0.92));
+
+  /* Depth */
+  --shadow-sm: 0 6px 16px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 12px 32px rgba(0, 0, 0, 0.42);
+  --shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.5);
+
+  /* Shape */
+  --radius-card: 18px;
+  --radius-control: 12px;
+  --radius-pill: 999px;
+
+  /* Spacing */
+  --space-2: 4px;
+  --space-3: 6px;
+  --space-4: 8px;
+  --space-5: 10px;
+  --space-6: 12px;
+  --space-8: 16px;
+  --space-10: 20px;
+  --space-12: 24px;
+  --space-16: 32px;
+
+  /* Typography */
+  --font-base: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-md: 1rem;
+  --font-size-lg: 1.1rem;
+  --line-height: 1.5;
+}
+
+html.theme-light,
+body.theme-light,
+.theme-light {
+  --color-bg: linear-gradient(135deg, #fff3e0, #ffe0c2);
+  --color-surface: rgba(255, 255, 255, 0.88);
+  --color-surface-muted: rgba(255, 255, 255, 0.76);
+  --color-surface-alt: rgba(255, 255, 255, 0.9);
+  --color-accent: #ff8a3d;
+  --color-accent-2: #ffce73;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-border-strong: rgba(255, 138, 61, 0.6);
+  --color-border-soft: rgba(255, 138, 61, 0.24);
+  --color-text: #0f172a;
+  --color-muted: #475569;
+  --color-disabled: rgba(71, 85, 105, 0.5);
+
+  --color-success: #128c62;
+  --color-warn: #c76a11;
+  --color-error: #d7263d;
+  --color-info: #0f6ac3;
+  --color-success-surface: rgba(18, 140, 98, 0.12);
+  --color-warn-surface: rgba(199, 106, 17, 0.12);
+  --color-error-surface: rgba(215, 38, 61, 0.12);
+  --color-info-surface: rgba(15, 106, 195, 0.12);
+
+  --gradient-overlay: radial-gradient(circle at 14% 18%, rgba(255, 184, 94, 0.12), transparent 36%),
+    radial-gradient(circle at 84% 12%, rgba(255, 129, 73, 0.16), transparent 34%);
+  --overlay-veil: linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.94));
+
+  --shadow-sm: 0 6px 14px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 10px 28px rgba(15, 23, 42, 0.12);
+  --shadow-lg: 0 14px 36px rgba(15, 23, 42, 0.14);
+}
+
+html,
+body,
+.d2ha-app {
+  font-family: var(--font-base);
+  color: var(--color-text);
+  background: var(--gradient-overlay), var(--color-bg);
+  min-height: 100vh;
+}
+
+.d2ha-app {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+  padding: var(--space-16);
+}
+
+.card {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
+    var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-12);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: -30% auto auto -40%;
+  width: 260px;
+  height: 260px;
+  background: radial-gradient(circle, rgba(49, 196, 255, 0.14), transparent 64%);
+  filter: blur(8px);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+  margin-bottom: var(--space-8);
+  padding-bottom: var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+  letter-spacing: 0.01em;
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-ghost,
+.btn-danger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-6) var(--space-10);
+  border-radius: var(--radius-pill);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  font-size: var(--font-size-sm);
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease, border-color 160ms ease;
+}
+
+.btn-primary {
+  background: var(--gradient-accent);
+  color: #0a0f1c;
+  box-shadow: 0 10px 30px rgba(49, 196, 255, 0.35);
+  border-color: var(--color-border-strong);
+}
+
+.btn-primary:hover { transform: translateY(-1px); }
+
+.btn-secondary {
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn-danger {
+  background: linear-gradient(135deg, #ef476f, #ff6b7d);
+  color: #13060d;
+  border-color: rgba(239, 71, 111, 0.5);
+  box-shadow: 0 10px 24px rgba(239, 71, 111, 0.35);
+}
+
+.btn-primary:active,
+.btn-secondary:active,
+.btn-ghost:active,
+.btn-danger:active {
+  transform: translateY(1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled,
+.btn-ghost:disabled,
+.btn-danger:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+  transform: none;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-8);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  font-size: var(--font-size-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.status-pill.success { color: var(--color-success); background: var(--color-success-surface); border-color: rgba(53, 196, 141, 0.28); }
+.status-pill.warn { color: var(--color-warn); background: var(--color-warn-surface); border-color: rgba(244, 178, 46, 0.28); }
+.status-pill.error { color: var(--color-error); background: var(--color-error-surface); border-color: rgba(239, 71, 111, 0.32); }
+.status-pill.info { color: var(--color-info); background: var(--color-info-surface); border-color: rgba(78, 168, 255, 0.3); }
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--font-size-sm);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+.table th,
+.table td {
+  padding: var(--space-8) var(--space-10);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.table thead th {
+  text-transform: uppercase;
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.04em;
+  color: var(--color-muted);
+  background: var(--color-surface-muted);
+}
+
+.table tbody tr:hover { background: var(--color-surface-muted); }
+
+.input {
+  width: 100%;
+  padding: var(--space-6) var(--space-8);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height);
+  transition: border-color 140ms ease, box-shadow 140ms ease;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-border-strong);
+  box-shadow: 0 0 0 3px var(--color-border-soft);
+}
+
+.input::placeholder { color: var(--color-muted); }
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+  padding: var(--space-8) var(--space-10);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-sm);
+}
+
+.toolbar .actions { display: flex; gap: var(--space-6); }
+
+.chip,
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-8);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-muted);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  font-size: var(--font-size-xs);
+  letter-spacing: 0.03em;
+}
+
+.chip strong,
+.pill strong { font-size: var(--font-size-sm); }


### PR DESCRIPTION
## Summary
- add d2ha theme variables covering palette, spacing, typography, and state colors
- provide component styles for app layout, cards, buttons, pills, tables, inputs, and toolbars with light/dark support

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692365e33d94832d95a2c7f5a6789d95)