### PR TITLE
Standardize tables and container controls

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Autodiscovery</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/d2ha-theme.css') }}">
   <style>
                 :root {
       --bg: #0f1116;
@@ -76,11 +77,11 @@
     .stack-content { border-top:1px solid var(--border); }
     .stack-content.collapsed { display:none; }
     .stack-actions { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
-    table { width:100%; border-collapse: collapse; table-layout: fixed; }
-    th, td { padding:10px 12px; border-bottom:1px solid var(--border); font-size:0.85rem; text-align:left; }
-    th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing:0.04em; font-size:0.78rem; }
-    tr:last-child td { border-bottom:none; }
-    tr:nth-child(even) td { background: rgba(255,255,255,0.01); }
+    .table { width:100%; border-collapse: collapse; table-layout: fixed; }
+    .table th, .table td { padding:10px 12px; border-bottom:1px solid var(--border); font-size:0.85rem; text-align:left; }
+    .table thead th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing:0.04em; font-size:0.78rem; }
+    .table tr:last-child td { border-bottom:none; }
+    .table tbody tr:nth-child(even) td { background: rgba(255,255,255,0.01); }
     .checkbox { display:flex; justify-content:center; align-items:center; }
     .checkbox-row { display:flex; align-items:center; justify-content:flex-start; gap:10px; flex-wrap:wrap; }
     .checkbox-item { display:flex; align-items:center; gap:8px; padding:10px 12px; border-radius:10px; border:1px solid var(--border); background: rgba(255,255,255,0.03); }
@@ -103,8 +104,8 @@
     .col-status { width: 140px; }
     .col-pref { width: 260px; }
     @media(max-width: 960px) {
-      table { min-width: 720px; }
-      th, td { font-size:0.82rem; }
+      .table { min-width: 720px; }
+      .table th, .table td { font-size:0.82rem; }
     }
   </style>
   {% include 'partials/notifications_styles.html' %}
@@ -155,7 +156,7 @@
             </div>
           </div>
           <div class="stack-content" style="overflow-x:auto;">
-            <table>
+            <table class="table">
               <colgroup>
                 <col class="col-name">
                 <col class="col-image">

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -30,14 +30,7 @@
     .stack-toggle-btn:hover { border-color: var(--color-border-strong); color: var(--color-accent); }
     .stack-toggle-btn .chevron { display:inline-block; width:10px; text-align:center; }
     .stack-content.collapsed { display:none; }
-    table { width:100%; border-collapse: collapse; background: var(--color-surface); border:1px solid var(--color-border); border-radius:12px; overflow:hidden; table-layout: fixed; }
-    th, td { padding:10px 12px; font-size:0.85rem; text-align:left; border-bottom:1px solid var(--color-border); vertical-align: middle; }
-    th { background: var(--color-surface-muted); color: var(--color-muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
-    tr:last-child td { border-bottom: none; }
-    tr:hover { background: var(--color-surface-muted); }
-    .status-pill.running { color: var(--color-success); background: var(--color-success-surface); border-color: rgba(53, 196, 141, 0.28); }
-    .status-pill.stopped { color: var(--color-warn); background: var(--color-warn-surface); border-color: rgba(244, 178, 46, 0.28); }
-    .status-pill.error { color: var(--color-error); background: var(--color-error-surface); border-color: rgba(239, 71, 111, 0.32); }
+    .table { table-layout: fixed; }
     .actions { display:flex; flex-wrap: wrap; gap:6px; justify-content:flex-end; }
     .actions .btn-primary, .actions .btn-secondary, .actions .btn-ghost { white-space:nowrap; }
     .actions-cell { text-align:right; }
@@ -59,6 +52,7 @@
     .bulk-bar.visible { display:flex; }
     .bulk-summary { color: var(--color-muted); font-weight:700; letter-spacing:0.02em; }
     .bulk-actions { display:flex; gap:8px; flex-wrap:wrap; }
+    .btn-icon { display:inline-flex; align-items:center; justify-content:center; }
     .modal-backdrop { position: fixed; inset:0; background: rgba(0,0,0,0.65); display:none; align-items:center; justify-content:center; z-index: 50; padding:20px; }
     .modal-backdrop.visible { display:flex; }
     .modal { background: var(--color-surface-muted); border:1px solid var(--color-border); border-radius:16px; width:min(1100px, 100%); height:82vh; max-height:82vh; overflow:hidden; box-shadow: var(--shadow-md); display:flex; flex-direction:column; }
@@ -163,7 +157,7 @@
           <div class="stack-chip">{{ stack.containers|length }} container</div>
         </div>
         <div class="card-body stack-content">
-          <table>
+          <table class="table">
             <colgroup>
               <col class="col-select">
               <col class="col-name">
@@ -208,11 +202,11 @@
                     {% set status = c.status.lower() %}
                     {% set css = "status-pill " %}
                     {% if status == "running" %}
-                      {% set css = css + "running" %}
+                      {% set css = css + "success" %}
                     {% elif status in ["restarting", "dead", "removing"] %}
                       {% set css = css + "error" %}
                     {% else %}
-                      {% set css = css + "stopped" %}
+                      {% set css = css + "warn" %}
                     {% endif %}
                     <span class="{{ css }}">{{ c.status }}</span>
                   </td>
@@ -262,10 +256,22 @@
   <div class="bulk-bar" id="bulk-bar" aria-hidden="true">
     <div class="bulk-summary"><span id="bulk-count">0</span> container selezionati</div>
     <div class="bulk-actions">
-      <button class="btn-primary" type="button" data-bulk-action="start">Avvia</button>
-      <button class="btn-secondary" type="button" data-bulk-action="stop">Ferma</button>
-      <button class="btn-secondary" type="button" data-bulk-action="restart">Riavvia</button>
-      <button class="btn-ghost" type="button" data-bulk-action="delete">Elimina</button>
+      <button class="btn-primary" type="button" data-bulk-action="start">
+        <span class="btn-icon" aria-hidden="true">▶</span>
+        <span>Avvia</span>
+      </button>
+      <button class="btn-secondary" type="button" data-bulk-action="stop">
+        <span class="btn-icon" aria-hidden="true">■</span>
+        <span>Ferma</span>
+      </button>
+      <button class="btn-secondary" type="button" data-bulk-action="restart">
+        <span class="btn-icon" aria-hidden="true">↻</span>
+        <span>Riavvia</span>
+      </button>
+      <button class="btn-danger" type="button" data-bulk-action="delete">
+        <span class="btn-icon" aria-hidden="true">🗑</span>
+        <span>Elimina</span>
+      </button>
     </div>
   </div>
 

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Eventi</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/d2ha-theme.css') }}">
   <style>
                 :root {
       --bg: #0f1116;
@@ -82,11 +83,11 @@
     .btn { border:none; border-radius:10px; padding:9px 14px; font-weight:700; cursor:pointer; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
     .table-card { padding:0; overflow:hidden; }
     .table-head { display:flex; justify-content:space-between; align-items:center; padding:14px 16px; border-bottom:1px solid var(--border); background: rgba(255,255,255,0.02); flex-wrap:wrap; gap:10px; }
-    table { width:100%; border-collapse: collapse; }
-    th, td { padding:10px 12px; text-align:left; font-size:0.85rem; border-bottom:1px solid var(--border); }
-    th { color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
-    tr:last-child td { border-bottom:none; }
-    tr:hover { background: rgba(255,255,255,0.03); }
+    .table { width:100%; border-collapse: collapse; }
+    .table th, .table td { padding:10px 12px; text-align:left; font-size:0.85rem; border-bottom:1px solid var(--border); }
+    .table th { color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
+    .table tr:last-child td { border-bottom:none; }
+    .table tbody tr:hover { background: rgba(255,255,255,0.03); }
     .sev-pill { display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border-radius:999px; font-weight:700; text-transform: uppercase; font-size:0.75rem; }
     .sev-dot { width:10px; height:10px; border-radius:50%; display:inline-block; }
     .sev-info { background: var(--accent-surface); color: #31c4ff; }
@@ -100,11 +101,11 @@
     .badge { padding:4px 8px; border-radius:8px; background: rgba(255,255,255,0.05); border:1px solid var(--border); font-size:0.8rem; }
     .empty { padding:18px; text-align:center; color: var(--muted); }
     @media (max-width: 960px) {
-      table, thead, tbody, th, td, tr { display:block; }
-      thead { display:none; }
-      tr { margin-bottom:10px; border:1px solid var(--border); border-radius:10px; overflow:hidden; }
-      td { display:flex; justify-content: space-between; border-bottom:1px solid var(--border); }
-      td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
+      .table, .table thead, .table tbody, .table th, .table td, .table tr { display:block; }
+      .table thead { display:none; }
+      .table tr { margin-bottom:10px; border:1px solid var(--border); border-radius:10px; overflow:hidden; }
+      .table td { display:flex; justify-content: space-between; border-bottom:1px solid var(--border); }
+      .table td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
     }
   </style>
   {% include 'partials/notifications_styles.html' %}
@@ -160,7 +161,7 @@
         </div>
         <div class="badge">{{ selected_hours }}h di cronologia · Severità: {{ 'Tutte' if selected_severity == 'all' else selected_severity|title }}</div>
       </div>
-      <table aria-label="Registro eventi di sistema">
+      <table class="table" aria-label="Registro eventi di sistema">
         <thead>
           <tr>
             <th>Data</th>

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Immagini</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/d2ha-theme.css') }}">
   <style>
                 :root {
       --bg: #0f1116;
@@ -62,11 +63,7 @@
     .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
-    table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; }
-    th, td { padding:10px 12px; font-size:0.85rem; text-align:left; border-bottom:1px solid var(--border); vertical-align: middle; }
-    th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
-    tr:last-child td { border-bottom: none; }
-    tr:hover { background: rgba(255,255,255,0.03); }
+    .table { table-layout: fixed; }
     .pill { padding:4px 10px; border-radius:999px; font-size:0.75rem; font-weight:700; text-transform: uppercase; display:inline-block; }
     .pill-used { background: rgba(124,255,195,0.15); color: #7cffc3; }
     .pill-unused { background: rgba(255,99,71,0.15); color: #ff8a7a; }
@@ -76,11 +73,11 @@
     .btn-danger { background:#b71c1c; }
     .btn:disabled { opacity:0.4; cursor:not-allowed; transform:none; }
     @media(max-width: 960px) {
-      table, thead, tbody, th, td, tr { display:block; }
-      thead { display:none; }
-      tr { margin-bottom:10px; border:1px solid var(--border); border-radius:10px; overflow:hidden; }
-      td { display:flex; justify-content: space-between; border-bottom:1px solid var(--border); }
-      td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
+      .table, .table thead, .table tbody, .table th, .table td, .table tr { display:block; }
+      .table thead { display:none; }
+      .table tr { margin-bottom:10px; border:1px solid var(--border); border-radius:10px; overflow:hidden; }
+      .table td { display:flex; justify-content: space-between; border-bottom:1px solid var(--border); }
+      .table td::before { content: attr(data-label); font-weight:700; color: var(--muted); margin-right: 10px; }
     }
   </style>
   {% include 'partials/notifications_styles.html' %}
@@ -109,7 +106,7 @@
       <div class="meta">Totale immagini: {{ images|length }} · Container attivi: {{ summary.running }}</div>
     </div>
     <section class="card">
-      <table>
+      <table class="table">
         <thead>
           <tr>
             <th>Tag</th>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Aggiornamenti</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/d2ha-theme.css') }}">
   <style>
                 :root {
       --bg: #0f1116;
@@ -62,11 +63,11 @@
     .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
-    table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
-    th, td { padding:12px 12px; font-size:0.88rem; text-align:left; border-bottom:1px solid var(--border); vertical-align: middle; line-height: 1.4; }
-    th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
-    tr:last-child td { border-bottom: none; }
-    tr:hover { background: rgba(255,255,255,0.03); }
+    .table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
+    .table th, .table td { padding:12px 12px; font-size:0.88rem; text-align:left; border-bottom:1px solid var(--border); vertical-align: middle; line-height: 1.4; }
+    .table thead th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
+    .table tbody tr:last-child td { border-bottom: none; }
+    .table tbody tr:hover { background: rgba(255,255,255,0.03); }
     .stack-tag { display:inline-flex; align-items:center; padding:2px 8px; border-radius:999px; background: rgba(156, 204, 101, 0.12); color: #c5e1a5; font-size: 0.78rem; }
     .stack-tag.nostack { background: rgba(158, 158, 158, 0.12); color: #e0e0e0; }
     .status-pill { display:inline-flex; align-items:center; padding: 2px 8px; border-radius: 999px; font-size: 0.75rem; font-weight: 700; }
@@ -115,12 +116,12 @@
     .confirm-actions { display:flex; justify-content:flex-end; gap:8px; }
     .btn-ghost { background: var(--control-surface); color: var(--text); border-color: var(--border); }
     @media(max-width: 1100px) {
-      table, thead, tbody, th, td, tr { display:block; }
-      thead { display:none; }
-      table { border-radius: 0; }
-      tr { margin-bottom:12px; border-radius:10px; overflow:hidden; border:1px solid var(--border); }
-      td { border-bottom:1px solid var(--border); display:flex; justify-content: space-between; }
-      td::before { content: attr(data-label); font-weight: 700; color: var(--muted); margin-right: 10px; }
+      .table, .table thead, .table tbody, .table th, .table td, .table tr { display:block; }
+      .table thead { display:none; }
+      .table { border-radius: 0; }
+      .table tr { margin-bottom:12px; border-radius:10px; overflow:hidden; border:1px solid var(--border); }
+      .table td { border-bottom:1px solid var(--border); display:flex; justify-content: space-between; }
+      .table td::before { content: attr(data-label); font-weight: 700; color: var(--muted); margin-right: 10px; }
     }
   </style>
   {% include 'partials/notifications_styles.html' %}
@@ -171,7 +172,7 @@
           <div class="stack-chip">{{ stack.containers|length }} container</div>
         </div>
         <div class="stack-body">
-          <table>
+          <table class="table">
             <colgroup>
               <col class="col-name">
               <col class="col-status">


### PR DESCRIPTION
## Summary
- apply the shared theme table styling to tables across containers, images, updates, events and autodiscovery views
- switch container status chips to use themed status-pill variants and refresh bulk action buttons with icons

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692369055dd0832d8d53290b3b38cfe4)