### PR TITLE
Restyle shared header across pages

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -52,9 +52,6 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
@@ -111,10 +108,7 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    <div class="brand-line">
-      <h1>D2HA</h1>
-      {% include 'partials/notifications_panel.html' %}
-    </div>
+    {% include 'partials/notifications_panel.html' %}
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -52,9 +52,6 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
@@ -178,10 +175,7 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    <div class="brand-line">
-      <h1>D2HA</h1>
-      {% include 'partials/notifications_panel.html' %}
-    </div>
+    {% include 'partials/notifications_panel.html' %}
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -67,9 +67,6 @@
       z-index: 10;
       box-shadow: var(--shadow);
     }
-    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
@@ -111,10 +108,7 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    <div class="brand-line">
-      <h1>D2HA</h1>
-      {% include 'partials/notifications_panel.html' %}
-    </div>
+    {% include 'partials/notifications_panel.html' %}
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -67,30 +67,6 @@
       z-index: 10;
       box-shadow: var(--shadow);
     }
-    .brand-line {
-      position: relative;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 12px;
-      flex-wrap: wrap;
-    }
-    .brand-line h1 {
-      margin: 0;
-      font-size: 1.35rem;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      text-align: center;
-    }
-    .brand-pill {
-      padding: 4px 10px;
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      background: var(--accent-surface);
-      color: var(--accent);
-      font-size: 0.8rem;
-      letter-spacing: 0.04em;
-    }
     nav {
       margin-top: 10px;
       display: flex;
@@ -381,20 +357,17 @@
 </head>
   <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
     <header>
-      <div class="brand-line">
-        <h1>D2HA</h1>
-        {% include 'partials/notifications_panel.html' %}
-      </div>
+      {% include 'partials/notifications_panel.html' %}
       <nav>
         <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
         <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
         <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
-      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
-      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
-      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
-      <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
-    </nav>
-  </header>
+        <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
+        <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
+        <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
+        <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
+      </nav>
+    </header>
 
   {% include 'partials/flash_messages.html' %}
 

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -52,9 +52,6 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
@@ -87,10 +84,7 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    <div class="brand-line">
-      <h1>D2HA</h1>
-      {% include 'partials/notifications_panel.html' %}
-    </div>
+    {% include 'partials/notifications_panel.html' %}
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>

--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -1,115 +1,121 @@
-<div class="header-actions header-actions-left">
-  <div class="header-clock" id="header-clock" aria-label="Orologio"></div>
-</div>
-
-<div class="header-actions header-actions-right">
-  <div id="backend-status-indicator" class="backend-status backend-status-ok" title="{{ t('settings.backend_status') }}" aria-label="{{ t('settings.backend_status') }}">
-    <svg class="backend-status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-      <path d="M3 10.5c5.5-5.5 12.5-5.5 18 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-      <path d="M6.5 14c3.25-3.25 7.75-3.25 11 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-      <path d="M10 17.5c1.1-1.1 2.9-1.1 4 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-      <circle cx="12" cy="20" r="1.25" fill="currentColor" />
-    </svg>
+<div class="header-bar">
+  <div class="header-section header-left">
+    <div class="header-clock" id="header-clock" aria-label="Orologio"></div>
   </div>
-  <div class="notif-area">
-    <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
-      <span class="notif-icon" aria-hidden="true">🔔</span>
-      <span class="notif-badge" id="notifBadge">0</span>
-    </button>
-    <div class="notif-panel" id="notifPanel" role="region" aria-label="{{ t('settings.notifications') }}">
-      <div class="notif-header">
-        <span>{{ t('settings.notifications') }}</span>
-      </div>
-      <div class="notif-list" id="notifList"></div>
+
+  <div class="header-section header-center">
+    <h1 class="header-title">D2HA</h1>
+  </div>
+
+  <div class="header-section header-right">
+    <div id="backend-status-indicator" class="backend-status backend-status-ok" title="{{ t('settings.backend_status') }}" aria-label="{{ t('settings.backend_status') }}">
+      <svg class="backend-status-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <path d="M3 10.5c5.5-5.5 12.5-5.5 18 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M6.5 14c3.25-3.25 7.75-3.25 11 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <path d="M10 17.5c1.1-1.1 2.9-1.1 4 0" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+        <circle cx="12" cy="20" r="1.25" fill="currentColor" />
+      </svg>
     </div>
-  </div>
-
-  <div class="settings-area">
-    <button class="settings-toggle" id="settingsToggle" aria-expanded="false" aria-controls="settingsPanel">
-      <span class="settings-icon" aria-hidden="true">⚙️</span>
-    </button>
-    <div class="settings-panel" id="settingsPanel" role="region" aria-label="{{ t('settings.title') }}">
-      <div class="settings-header">
-        <span>{{ t('settings.title') }}</span>
+    <div class="notif-area">
+      <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
+        <span class="notif-icon" aria-hidden="true">🔔</span>
+        <span class="notif-badge" id="notifBadge">0</span>
+      </button>
+      <div class="notif-panel" id="notifPanel" role="region" aria-label="{{ t('settings.notifications') }}">
+        <div class="notif-header">
+          <span>{{ t('settings.notifications') }}</span>
+        </div>
+        <div class="notif-list" id="notifList"></div>
       </div>
-      <div class="settings-body">
-        <div class="settings-row">
-          <span>{{ t('settings.os') }}</span>
-          <strong>{{ system_info.os }}</strong>
+    </div>
+
+    <div class="settings-area">
+      <button class="settings-toggle" id="settingsToggle" aria-expanded="false" aria-controls="settingsPanel">
+        <span class="settings-icon" aria-hidden="true">⚙️</span>
+      </button>
+      <div class="settings-panel" id="settingsPanel" role="region" aria-label="{{ t('settings.title') }}">
+        <div class="settings-header">
+          <span>{{ t('settings.title') }}</span>
         </div>
-        <div class="settings-row">
-          <span>{{ t('settings.docker') }}</span>
-          <strong>{{ system_info.docker_version }}</strong>
-        </div>
-        <div class="settings-row">
-          <span>{{ t('settings.uptime') }}</span>
-          <strong>{{ system_info.uptime }}</strong>
-        </div>
-        <div class="settings-row">
-          <div>
-            <span>{{ t('nav.security') }}</span>
-            <p class="settings-hint">{{ t('settings.security_hint') }}</p>
+        <div class="settings-body">
+          <div class="settings-row">
+            <span>{{ t('settings.os') }}</span>
+            <strong>{{ system_info.os }}</strong>
           </div>
-          <a class="settings-link settings-link-icon" href="{{ url_for('security_settings') }}" aria-label="Apri impostazioni di sicurezza">
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <path d="M12 3l7 4v5c0 4.97-3.58 9.36-7 9.97-3.42-.61-7-5-7-9.97V7l7-4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
-              <path d="M9.5 12.5l2 2 3-3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
-          </a>
-        </div>
-        <div class="settings-row settings-row-toggle">
-          <div>
-            <span>{{ t('performance_mode.label') }}</span>
-            <p class="settings-hint">{{ t('settings.performance_hint') }}</p>
+          <div class="settings-row">
+            <span>{{ t('settings.docker') }}</span>
+            <strong>{{ system_info.docker_version }}</strong>
           </div>
-          <div class="switch" title="Riduce il carico iniziale e le frequenze di refresh">
-            <input type="checkbox" id="performance-mode-toggle" />
-            <span class="slider"></span>
+          <div class="settings-row">
+            <span>{{ t('settings.uptime') }}</span>
+            <strong>{{ system_info.uptime }}</strong>
           </div>
-        </div>
-        <div class="settings-safe">
-          <div>
-            <div class="settings-row">
-              <span>{{ t('safe_mode.label') }}</span>
-              <div class="switch" title="Richiedi conferma per le operazioni sensibili">
-                <input type="checkbox" id="safeModeToggle" {% if safe_mode_enabled %}checked{% endif %} />
-                <span class="slider"></span>
-              </div>
+          <div class="settings-row">
+            <div>
+              <span>{{ t('nav.security') }}</span>
+              <p class="settings-hint">{{ t('settings.security_hint') }}</p>
             </div>
-            <p class="settings-hint">{{ t('settings.safe_hint') }}</p>
+            <a class="settings-link settings-link-icon" href="{{ url_for('security_settings') }}" aria-label="Apri impostazioni di sicurezza">
+              <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M12 3l7 4v5c0 4.97-3.58 9.36-7 9.97-3.42-.61-7-5-7-9.97V7l7-4z" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round" />
+                <path d="M9.5 12.5l2 2 3-3.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </a>
           </div>
-        </div>
-        <div class="settings-row settings-row-toggle">
-          <div>
-            <span>{{ t('theme.label') }}</span>
-            <p class="settings-hint">{{ t('theme.switch_label') }}</p>
+          <div class="settings-row settings-row-toggle">
+            <div>
+              <span>{{ t('performance_mode.label') }}</span>
+              <p class="settings-hint">{{ t('settings.performance_hint') }}</p>
+            </div>
+            <div class="switch" title="Riduce il carico iniziale e le frequenze di refresh">
+              <input type="checkbox" id="performance-mode-toggle" />
+              <span class="slider"></span>
+            </div>
           </div>
-          <form method="post" action="{{ url_for('set_theme') }}">
-            <input type="hidden" name="next" value="{{ request.path }}">
-            <select name="theme" onchange="this.form.submit()">
-              {% for theme in SUPPORTED_THEMES %}
-              <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>
-                {{ t('theme.' + theme) }}
-              </option>
-              {% endfor %}
-            </select>
-          </form>
-        </div>
-        <div class="settings-row settings-row-toggle">
-          <div>
-            <span>{{ t('language.label') }}</span>
-            <p class="settings-hint">{{ t('wizard.step1.title') }}</p>
+          <div class="settings-safe">
+            <div>
+              <div class="settings-row">
+                <span>{{ t('safe_mode.label') }}</span>
+                <div class="switch" title="Richiedi conferma per le operazioni sensibili">
+                  <input type="checkbox" id="safeModeToggle" {% if safe_mode_enabled %}checked{% endif %} />
+                  <span class="slider"></span>
+                </div>
+              </div>
+              <p class="settings-hint">{{ t('settings.safe_hint') }}</p>
+            </div>
           </div>
-          <form method="post" action="{{ url_for('set_language') }}">
-            <input type="hidden" name="next" value="{{ request.path }}">
-            <select name="lang" onchange="this.form.submit()">
-              {% for lang_code in SUPPORTED_LANGS %}
-              <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
-                {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
-              </option>
-              {% endfor %}
-            </select>
-          </form>
+          <div class="settings-row settings-row-toggle">
+            <div>
+              <span>{{ t('theme.label') }}</span>
+              <p class="settings-hint">{{ t('theme.switch_label') }}</p>
+            </div>
+            <form method="post" action="{{ url_for('set_theme') }}">
+              <input type="hidden" name="next" value="{{ request.path }}">
+              <select name="theme" onchange="this.form.submit()">
+                {% for theme in SUPPORTED_THEMES %}
+                <option value="{{ theme }}" {% if get_current_theme() == theme %}selected{% endif %}>
+                  {{ t('theme.' + theme) }}
+                </option>
+                {% endfor %}
+              </select>
+            </form>
+          </div>
+          <div class="settings-row settings-row-toggle">
+            <div>
+              <span>{{ t('language.label') }}</span>
+              <p class="settings-hint">{{ t('wizard.step1.title') }}</p>
+            </div>
+            <form method="post" action="{{ url_for('set_language') }}">
+              <input type="hidden" name="next" value="{{ request.path }}">
+              <select name="lang" onchange="this.form.submit()">
+                {% for lang_code in SUPPORTED_LANGS %}
+                <option value="{{ lang_code }}" {% if get_current_lang() == lang_code %}selected{% endif %}>
+                  {{ t('language.italian') if lang_code == 'it' else t('language.english') }}
+                </option>
+                {% endfor %}
+              </select>
+            </form>
+          </div>
         </div>
       </div>
     </div>

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -1,91 +1,74 @@
 <style>
-  .header-actions {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    display: flex;
+  .header-bar {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     align-items: center;
-    gap: 10px;
+    gap: 12px;
+    padding: 10px 14px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    box-shadow: var(--shadow);
   }
-
-  .header-actions-right { right: 0; }
-
-  .header-actions-left { left: 0; }
-  .backend-status {
+  .header-section { display: flex; align-items: center; gap: 10px; min-width: 0; }
+  .header-left { justify-content: flex-start; }
+  .header-center { justify-content: center; }
+  .header-right { justify-content: flex-end; gap: 10px; }
+  .header-title {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    font-size: 1.1rem;
+    color: var(--text);
+    text-align: center;
+    text-shadow: 0 0 12px var(--accent-glow-soft);
+  }
+  .backend-status,
+  .notif-toggle,
+  .settings-toggle {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin-right: 0.75rem;
+    background: var(--control-surface);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 12px;
+    height: 40px;
+    min-width: 40px;
+    padding: 6px 10px;
     cursor: pointer;
-    transition: color 0.2s ease, opacity 0.2s ease;
-    color: #4caf50;
+    box-shadow: var(--shadow);
+    transition: border-color 0.15s ease, transform 0.08s ease, color 0.15s ease;
   }
-  .backend-status:hover { opacity: 0.9; }
+  .backend-status:hover,
+  .notif-toggle:hover,
+  .settings-toggle:hover { border-color: var(--accent-border); color: var(--accent); transform: translateY(-1px); }
   .backend-status-ok { color: #4caf50; }
   .backend-status-degraded { color: #ff9800; }
   .backend-status-down { color: #f44336; }
-  .backend-status-updating {
-    color: #31c4ff;
-    animation: backend-status-pulse 1s ease-in-out infinite;
-  }
-  .backend-status-icon {
-    width: 20px;
-    height: 20px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    line-height: 1;
-  }
+  .backend-status-updating { color: #31c4ff; animation: backend-status-pulse 1s ease-in-out infinite; }
+  .backend-status-icon { width: 20px; height: 20px; display: inline-flex; align-items: center; justify-content: center; line-height: 1; }
   .backend-status-icon path { stroke: currentColor; }
   .backend-status-icon circle { fill: currentColor; }
-  @keyframes backend-status-pulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.4; }
-  }
+  @keyframes backend-status-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
   .header-clock {
     font-family: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
     padding: 10px 12px;
-    border-radius: 10px;
+    border-radius: 12px;
     border: 1px solid var(--border);
     background: var(--control-surface);
     color: var(--text);
     letter-spacing: 0.08em;
     box-shadow: var(--shadow);
-    min-width: 110px;
+    min-width: 120px;
     text-align: center;
   }
   .notif-area,
-  .settings-area {
-    position: relative;
-    display: flex;
-    align-items: center;
-  }
+  .settings-area { position: relative; display: flex; align-items: center; }
   .notif-toggle,
-  .settings-toggle {
-    position: relative;
-    background: var(--control-surface);
-    border: 1px solid var(--border);
-    color: var(--text);
-    border-radius: 10px;
-    padding: 8px 12px;
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    box-shadow: var(--shadow);
-  }
-  .notif-toggle:hover,
-  .settings-toggle:hover { border-color: rgba(49,196,255,0.5); }
+  .settings-toggle { gap: 8px; }
   .notif-icon,
-  .settings-icon {
-    width: 16px;
-    height: 16px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1rem;
-    line-height: 1;
-  }
+  .settings-icon { width: 16px; height: 16px; display: inline-flex; align-items: center; justify-content: center; font-size: 1rem; line-height: 1; }
   .notif-badge {
     min-width: 20px;
     height: 20px;
@@ -99,6 +82,11 @@
     font-size: 0.8rem;
     padding: 0 6px;
     box-shadow: 0 4px 12px rgba(255,99,71,0.35);
+  }
+  @media (max-width: 720px) {
+    .header-bar { grid-template-columns: 1fr; text-align: center; gap: 10px; }
+    .header-left, .header-right { justify-content: center; }
+    .header-right { flex-wrap: wrap; }
   }
   .backend-modal-backdrop {
     position: fixed;

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -68,30 +68,6 @@
       z-index: 10;
       box-shadow: var(--shadow);
     }
-    .brand-line {
-      position: relative;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 12px;
-      flex-wrap: wrap;
-    }
-    .brand-line h1 {
-      margin: 0;
-      font-size: 1.35rem;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      text-align: center;
-    }
-    .brand-pill {
-      padding: 4px 10px;
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      background: var(--accent-surface);
-      color: var(--accent);
-      font-size: 0.8rem;
-      letter-spacing: 0.04em;
-    }
     nav {
       margin-top: 10px;
       display: flex;
@@ -198,10 +174,7 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    <div class="brand-line">
-      <h1>D2HA</h1>
-      {% include 'partials/notifications_panel.html' %}
-    </div>
+    {% include 'partials/notifications_panel.html' %}
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -52,9 +52,6 @@
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    .brand-line { position: relative; display:flex; align-items:center; justify-content:center; gap:12px; flex-wrap:wrap; }
-    .brand-line h1 { margin:0; font-size:1.35rem; letter-spacing:0.12em; text-transform:uppercase; text-align:center; }
-    .brand-pill { padding:4px 10px; border-radius:999px; border:1px solid var(--border); background: var(--accent-surface); color: var(--accent); font-size:0.8rem; letter-spacing:0.04em; }
     nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
     .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
     .tab:hover { color: var(--text); border-color: var(--border); }
@@ -127,10 +124,7 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    <div class="brand-line">
-      <h1>D2HA</h1>
-      {% include 'partials/notifications_panel.html' %}
-    </div>
+    {% include 'partials/notifications_panel.html' %}
     <nav>
       <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
       <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>


### PR DESCRIPTION
## Summary
- replace per-page brand header markup with shared panel including centered D2HA title and ordered icons
- refresh header styling to match login/wizard palettes across light and dark themes with responsive grid layout
- keep navigation intact while standardizing top bar across all authenticated views

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ab4cc088832dbda5965a70084586)