### PR TITLE
Unify app header panel layout

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -25,6 +25,8 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
+      --auth-bg-1: #0a1024;
+      --auth-bg-2: #0f1b3f;
     }
 
     body.theme-light {
@@ -47,16 +49,41 @@
       --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
       --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
       --control-surface: #fffaf3;
+      --auth-bg-1: #ffe9d6;
+      --auth-bg-2: #ffd0a1;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
-    .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
-    .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
-    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
+    header {
+      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
+                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border-bottom:1px solid var(--border);
+      padding:16px 18px;
+      box-shadow: var(--shadow);
+      position:sticky;
+      top:0;
+      z-index:10;
+      backdrop-filter: blur(6px);
+    }
+    .header-shell {
+      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+      padding: 12px 14px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
+    .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
+    .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .meta { color: var(--muted); font-size:0.9rem; }
@@ -108,16 +135,18 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    {% include 'partials/notifications_panel.html' %}
-    <nav>
-      <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
-      <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
-      <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
-      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
-      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
-      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
-      <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
-    </nav>
+    <div class="header-shell">
+      {% include 'partials/notifications_panel.html' %}
+      <nav>
+        <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+        <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
+        <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
+        <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
+        <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
+        <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
+        <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
+      </nav>
+    </div>
   </header>
 
   {% include 'partials/flash_messages.html' %}

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -25,6 +25,8 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
+      --auth-bg-1: #0a1024;
+      --auth-bg-2: #0f1b3f;
     }
 
     body.theme-light {
@@ -47,16 +49,41 @@
       --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
       --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
       --control-surface: #fffaf3;
+      --auth-bg-1: #ffe9d6;
+      --auth-bg-2: #ffd0a1;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
-    .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
-    .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
-    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
+    header {
+      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
+                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border-bottom:1px solid var(--border);
+      padding:16px 18px;
+      box-shadow: var(--shadow);
+      position:sticky;
+      top:0;
+      z-index:10;
+      backdrop-filter: blur(6px);
+    }
+    .header-shell {
+      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+      padding: 12px 14px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
+    .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
+    .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 16px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .stack-card { display:flex; flex-direction:column; gap:12px; }
@@ -175,16 +202,18 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    {% include 'partials/notifications_panel.html' %}
-    <nav>
-      <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
-      <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
-      <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
-      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
-      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
-      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
-      <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
-    </nav>
+    <div class="header-shell">
+      {% include 'partials/notifications_panel.html' %}
+      <nav>
+        <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+        <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
+        <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
+        <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
+        <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
+        <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
+        <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
+      </nav>
+    </div>
   </header>
 
   {% include 'partials/flash_messages.html' %}

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -25,6 +25,8 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
+      --auth-bg-1: #0a1024;
+      --auth-bg-2: #0f1b3f;
     }
 
     body.theme-light {
@@ -47,6 +49,8 @@
       --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
       --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
       --control-surface: #fffaf3;
+      --auth-bg-1: #ffe9d6;
+      --auth-bg-2: #ffd0a1;
     }
     * { box-sizing: border-box; }
     body {
@@ -59,19 +63,34 @@
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: var(--header-bg);
+      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
+                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
       border-bottom: 1px solid var(--border);
-      padding: 16px 22px 12px;
+      padding: 16px 18px;
       position: sticky;
       top: 0;
       z-index: 10;
       box-shadow: var(--shadow);
+      backdrop-filter: blur(6px);
     }
-    nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
-    .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
-    .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
-    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
+    .header-shell {
+      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+      padding: 12px 14px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    nav { margin-top:0; display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
+    .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
+    .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     .filters { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
@@ -108,16 +127,18 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    {% include 'partials/notifications_panel.html' %}
-    <nav>
-      <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
-      <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
-      <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
-      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
-      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
-      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
-      <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
-    </nav>
+    <div class="header-shell">
+      {% include 'partials/notifications_panel.html' %}
+      <nav>
+        <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+        <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
+        <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
+        <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
+        <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
+        <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
+        <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
+      </nav>
+    </div>
   </header>
 
   {% include 'partials/flash_messages.html' %}

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -25,6 +25,8 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
+      --auth-bg-1: #0a1024;
+      --auth-bg-2: #0f1b3f;
     }
 
     body.theme-light {
@@ -47,6 +49,8 @@
       --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
       --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
       --control-surface: #fffaf3;
+      --auth-bg-1: #ffe9d6;
+      --auth-bg-2: #ffd0a1;
     }
     * { box-sizing: border-box; }
     body {
@@ -59,40 +63,62 @@
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: var(--header-bg);
+      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
+                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
       border-bottom: 1px solid var(--border);
-      padding: 16px 22px 12px;
+      padding: 16px 18px;
       position: sticky;
       top: 0;
       z-index: 10;
       box-shadow: var(--shadow);
+      backdrop-filter: blur(6px);
+    }
+    .header-shell {
+      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+      padding: 12px 14px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
     }
     nav {
-      margin-top: 10px;
       display: flex;
-      gap: 8px;
       flex-wrap: wrap;
+      gap: 8px;
+      background: rgba(12, 18, 30, 0.35);
+      border: 1px solid var(--accent-border-soft);
+      border-radius: 12px;
+      padding: 8px;
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
     }
     .tab {
-      padding: 8px 14px;
-      border-radius: 8px;
-      background: rgba(255,255,255,0.04);
+      padding: 9px 14px;
+      border-radius: 10px;
+      background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02));
       color: var(--muted);
-      font-weight: 600;
-      border: 1px solid transparent;
+      font-weight: 700;
+      border: 1px solid rgba(255,255,255,0.08);
       transition: all 0.15s ease;
+      box-shadow: 0 6px 18px rgba(0,0,0,0.28);
     }
-    .tab:hover { color: var(--text); border-color: var(--border); }
+    .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
     .tab.active {
       background: var(--accent-gradient);
       color: #0c121e;
-      box-shadow: 0 6px 18px var(--accent-glow);
+      box-shadow: 0 10px 26px var(--accent-glow);
+      border-color: var(--accent-border);
     }
     .logout-link {
       margin-left: auto;
-      background: var(--accent-gradient);
-      color: #0c121e;
-      box-shadow: 0 6px 18px var(--accent-glow-soft);
+      background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06));
+      color: var(--text);
+      box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35);
+      border-color: var(--border);
     }
     .layout {
       display: grid;
@@ -357,16 +383,18 @@
 </head>
   <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
     <header>
-      {% include 'partials/notifications_panel.html' %}
-      <nav>
-        <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
-        <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
-        <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
-        <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
-        <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
-        <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
-        <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
-      </nav>
+      <div class="header-shell">
+        {% include 'partials/notifications_panel.html' %}
+        <nav>
+          <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+          <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
+          <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
+          <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
+          <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
+          <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
+          <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
+        </nav>
+      </div>
     </header>
 
   {% include 'partials/flash_messages.html' %}

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -25,6 +25,8 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
+      --auth-bg-1: #0a1024;
+      --auth-bg-2: #0f1b3f;
     }
 
     body.theme-light {
@@ -47,16 +49,41 @@
       --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
       --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
       --control-surface: #fffaf3;
+      --auth-bg-1: #ffe9d6;
+      --auth-bg-2: #ffd0a1;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
-    .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
-    .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
-    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
+    header {
+      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
+                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border-bottom:1px solid var(--border);
+      padding:16px 18px;
+      box-shadow: var(--shadow);
+      position:sticky;
+      top:0;
+      z-index:10;
+      backdrop-filter: blur(6px);
+    }
+    .header-shell {
+      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+      padding: 12px 14px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
+    .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
+    .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; }
@@ -84,16 +111,18 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    {% include 'partials/notifications_panel.html' %}
-    <nav>
-      <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
-      <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
-      <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
-      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
-      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
-      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
-      <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
-    </nav>
+    <div class="header-shell">
+      {% include 'partials/notifications_panel.html' %}
+      <nav>
+        <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+        <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
+        <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
+        <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
+        <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
+        <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
+        <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
+      </nav>
+    </div>
   </header>
 
   {% include 'partials/flash_messages.html' %}

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -25,6 +25,8 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
+      --auth-bg-1: #0a1024;
+      --auth-bg-2: #0f1b3f;
     }
 
     body.theme-light {
@@ -47,16 +49,41 @@
       --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
       --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
       --control-surface: #fffaf3;
+      --auth-bg-1: #ffe9d6;
+      --auth-bg-2: #ffd0a1;
     }
     * { box-sizing: border-box; }
     body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
     a { color: inherit; text-decoration: none; }
-    header { background: var(--header-bg); border-bottom:1px solid var(--border); padding:16px 22px 12px; box-shadow: var(--shadow); position:sticky; top:0; z-index:10; }
-    nav { margin-top:10px; display:flex; gap:8px; flex-wrap:wrap; }
-    .tab { padding:8px 14px; border-radius:8px; background: rgba(255,255,255,0.04); color: var(--muted); font-weight:600; border:1px solid transparent; transition: all 0.15s ease; }
-    .tab:hover { color: var(--text); border-color: var(--border); }
-    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
-    .logout-link { margin-left:auto; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow-soft); }
+    header {
+      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
+                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border-bottom:1px solid var(--border);
+      padding:16px 18px;
+      box-shadow: var(--shadow);
+      position:sticky;
+      top:0;
+      z-index:10;
+      backdrop-filter: blur(6px);
+    }
+    .header-shell {
+      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
+                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+      padding: 12px 14px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
+    .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
+    .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
+    .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
     .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
     table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
@@ -124,16 +151,18 @@
 </head>
 <body class="theme-{{ get_current_theme() }}" data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}" data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}">
   <header>
-    {% include 'partials/notifications_panel.html' %}
-    <nav>
-      <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
-      <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
-      <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
-      <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
-      <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
-      <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
-      <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
-    </nav>
+    <div class="header-shell">
+      {% include 'partials/notifications_panel.html' %}
+      <nav>
+        <a href="{{ url_for('index') }}" class="tab {{ 'active' if active_page == 'home' else '' }}">Home</a>
+        <a href="{{ url_for('containers_view') }}" class="tab {{ 'active' if active_page == 'containers' else '' }}">{{ t("nav.containers") }}</a>
+        <a href="{{ url_for('images_view') }}" class="tab {{ 'active' if active_page == 'images' else '' }}">{{ t("nav.images") }}</a>
+        <a href="{{ url_for('updates') }}" class="tab {{ 'active' if active_page == 'updates' else '' }}">{{ t("nav.updates") }}</a>
+        <a href="{{ url_for('events_view') }}" class="tab {{ 'active' if active_page == 'events' else '' }}">{{ t("nav.events") }}</a>
+        <a href="{{ url_for('autodiscovery_view') }}" class="tab {{ 'active' if active_page == 'autodiscovery' else '' }}">{{ t("nav.autodiscovery") }}</a>
+        <a href="{{ url_for('logout') }}" class="tab logout-link">{{ t("nav.logout") }}</a>
+      </nav>
+    </div>
   </header>
 
   {% include 'partials/flash_messages.html' %}


### PR DESCRIPTION
## Summary
- integrate navigation tabs into the same header shell as the clock, title, and controls
- refresh header styling with the login/wizard gradient palette for light and dark themes
- apply the unified header treatment across home, containers, images, updates, events, and autodiscovery pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923afbfb2f4832dab39e29434962ba7)