### PR TITLE
Refactor header into single card layout

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -79,7 +79,13 @@
       flex-direction: column;
       gap: 10px;
     }
-    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 4px 2px 0;
+      align-items: center;
+    }
     .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
     .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -79,7 +79,13 @@
       flex-direction: column;
       gap: 10px;
     }
-    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 4px 2px 0;
+      align-items: center;
+    }
     .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
     .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -86,7 +86,14 @@
       flex-direction: column;
       gap: 10px;
     }
-    nav { margin-top:0; display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    nav {
+      margin-top: 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 4px 2px 0;
+      align-items: center;
+    }
     .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
     .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -90,11 +90,8 @@
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
-      background: rgba(12, 18, 30, 0.35);
-      border: 1px solid var(--accent-border-soft);
-      border-radius: 12px;
-      padding: 8px;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.04);
+      padding: 4px 2px 0;
+      align-items: center;
     }
     .tab {
       padding: 9px 14px;

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -79,7 +79,13 @@
       flex-direction: column;
       gap: 10px;
     }
-    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 4px 2px 0;
+      align-items: center;
+    }
     .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
     .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -4,11 +4,7 @@
     grid-template-columns: 1fr auto 1fr;
     align-items: center;
     gap: 12px;
-    padding: 10px 14px;
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
-    border: 1px solid var(--border);
-    border-radius: 16px;
-    box-shadow: var(--shadow);
+    padding: 4px 2px;
   }
   .header-section { display: flex; align-items: center; gap: 10px; min-width: 0; }
   .header-left { justify-content: flex-start; }

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -73,6 +73,8 @@
       display: flex;
       gap: 8px;
       flex-wrap: wrap;
+      padding: 4px 2px 0;
+      align-items: center;
     }
     .tab {
       padding: 8px 14px;

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -79,7 +79,13 @@
       flex-direction: column;
       gap: 10px;
     }
-    nav { display:flex; flex-wrap:wrap; gap:8px; background: linear-gradient(145deg, rgba(255,255,255,0.1), rgba(255,255,255,0.04)); border:1px solid var(--accent-border-soft); border-radius:12px; padding:8px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      padding: 4px 2px 0;
+      align-items: center;
+    }
     .tab { padding:9px 14px; border-radius:10px; background: linear-gradient(145deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)); color: var(--muted); font-weight:700; border:1px solid rgba(255,255,255,0.08); transition: all 0.15s ease; box-shadow:0 6px 18px rgba(0,0,0,0.28); }
     .tab:hover { color: var(--text); border-color: var(--accent-border-soft); background: rgba(255,255,255,0.06); }
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }


### PR DESCRIPTION
## Summary
- remove inner header bar borders so the clock/title/icons sit directly within the header container
- streamline navigation bar styling across pages to align with the single-card header layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b432e5e0832d907e5332dce979cd)