### PR TITLE
Unify dashboard theme backgrounds

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Autodiscovery</title>
   <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
+    :root {
+      --bg-base: #0b1020;
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(124,255,195,0.06), transparent 24%),
+                    linear-gradient(135deg, #0b1020, #10162c 60%, #0f1b3f 100%);
+      --bg-card: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)),
+                  rgba(17, 22, 36, 0.92);
+      --bg-card-alt: linear-gradient(160deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)),
+                     rgba(26, 34, 52, 0.86);
+      --accent-primary: #31c4ff;
+      --accent: var(--accent-primary);
       --accent-2: #7cffc3;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
       --accent-glow: rgba(49,196,255,0.35);
@@ -25,18 +32,26 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
-      --auth-bg-1: #0a1024;
-      --auth-bg-2: #0f1b3f;
+      --bg: var(--bg-base);
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
 
     body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
+      --bg-base: linear-gradient(135deg, #fff3e0, #ffe0c2);
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(255, 184, 94, 0.18), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(255, 129, 73, 0.16), transparent 24%),
+                    var(--bg-base);
+      --bg-card: linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.78)),
+                  linear-gradient(180deg, rgba(255, 138, 61, 0.12), rgba(255, 206, 115, 0.06)),
+                  #ffffff;
+      --bg-card-alt: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.84)),
+                     #fff7ed;
+      --accent-primary: #f97316;
+      --accent: var(--accent-primary);
       --accent-2: #fb923c;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow: rgba(249,115,22,0.28);
       --accent-glow-soft: rgba(249,115,22,0.18);
       --accent-border-strong: rgba(249,115,22,0.55);
       --accent-border: rgba(249,115,22,0.42);
@@ -46,19 +61,20 @@
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --header-bg: linear-gradient(90deg, #fff0e0, #ffe1bf);
+      --stack-header-bg: linear-gradient(135deg, #ffe8cc, #ffd6a5);
       --control-surface: #fffaf3;
       --auth-bg-1: #ffe9d6;
       --auth-bg-2: #ffd0a1;
+      --bg: #fff7ed;
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
     * { box-sizing: border-box; }
-    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg-primary); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header {
-      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
-                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-primary);
       border-bottom:1px solid var(--border);
       padding:16px 18px;
       box-shadow: var(--shadow);
@@ -68,9 +84,7 @@
       backdrop-filter: blur(6px);
     }
     .header-shell {
-      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
-                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: 18px;
       box-shadow: var(--shadow);
@@ -91,11 +105,11 @@
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
     .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
-    .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
+    .card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:14px 16px; box-shadow: var(--shadow); }
     .meta { color: var(--muted); font-size:0.9rem; }
     .title { margin:0 0 6px 0; font-size:1rem; }
     .stacks { display:flex; flex-direction:column; gap:14px; }
-    .stack { background: var(--panel); border:1px solid var(--border); border-radius:14px; box-shadow: var(--shadow); overflow:hidden; }
+    .stack { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; box-shadow: var(--shadow); overflow:hidden; }
     .stack-header { display:flex; align-items:center; justify-content:space-between; padding:12px 14px; border-bottom:1px solid var(--border); gap:10px; flex-wrap:wrap; }
     .stack-header.stack-toggle { cursor:pointer; border-bottom-width:0; }
     .stack-title { font-weight:700; font-size:1rem; letter-spacing:0.08em; display:flex; align-items:center; gap:8px; text-transform: uppercase; }

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Container</title>
   <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
+    :root {
+      --bg-base: #0b1020;
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(124,255,195,0.06), transparent 24%),
+                    linear-gradient(135deg, #0b1020, #10162c 60%, #0f1b3f 100%);
+      --bg-card: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)),
+                  rgba(17, 22, 36, 0.92);
+      --bg-card-alt: linear-gradient(160deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)),
+                     rgba(26, 34, 52, 0.86);
+      --accent-primary: #31c4ff;
+      --accent: var(--accent-primary);
       --accent-2: #7cffc3;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
       --accent-glow: rgba(49,196,255,0.35);
@@ -25,18 +32,26 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
-      --auth-bg-1: #0a1024;
-      --auth-bg-2: #0f1b3f;
+      --bg: var(--bg-base);
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
 
     body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
+      --bg-base: linear-gradient(135deg, #fff3e0, #ffe0c2);
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(255, 184, 94, 0.18), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(255, 129, 73, 0.16), transparent 24%),
+                    var(--bg-base);
+      --bg-card: linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.78)),
+                  linear-gradient(180deg, rgba(255, 138, 61, 0.12), rgba(255, 206, 115, 0.06)),
+                  #ffffff;
+      --bg-card-alt: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.84)),
+                     #fff7ed;
+      --accent-primary: #f97316;
+      --accent: var(--accent-primary);
       --accent-2: #fb923c;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow: rgba(249,115,22,0.28);
       --accent-glow-soft: rgba(249,115,22,0.18);
       --accent-border-strong: rgba(249,115,22,0.55);
       --accent-border: rgba(249,115,22,0.42);
@@ -46,19 +61,20 @@
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --header-bg: linear-gradient(90deg, #fff0e0, #ffe1bf);
+      --stack-header-bg: linear-gradient(135deg, #ffe8cc, #ffd6a5);
       --control-surface: #fffaf3;
       --auth-bg-1: #ffe9d6;
       --auth-bg-2: #ffd0a1;
+      --bg: #fff7ed;
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
     * { box-sizing: border-box; }
-    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg-primary); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header {
-      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
-                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-primary);
       border-bottom:1px solid var(--border);
       padding:16px 18px;
       box-shadow: var(--shadow);
@@ -68,9 +84,7 @@
       backdrop-filter: blur(6px);
     }
     .header-shell {
-      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
-                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: 18px;
       box-shadow: var(--shadow);
@@ -91,9 +105,9 @@
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
     .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 16px; }
-    .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
+    .card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:14px 16px; box-shadow: var(--shadow); }
     .stack-card { display:flex; flex-direction:column; gap:12px; }
-    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:2px; padding:12px 14px; border:1px solid var(--border); border-radius:12px; background: var(--stack-header-bg); box-shadow: var(--shadow); }
+    .stack-header { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-bottom:2px; padding:12px 14px; border:1px solid var(--border); border-radius:14px; background: var(--bg-card-alt); box-shadow: var(--shadow); }
     .stack-toggle { margin-bottom:0; cursor:pointer; }
     .stack-title { font-size:1rem; font-weight:800; display:flex; align-items:center; gap:10px; letter-spacing:0.02em; }
     .stack-name { text-transform: uppercase; letter-spacing:0.08em; }
@@ -102,7 +116,7 @@
     .stack-toggle-btn:hover { border-color: var(--accent-border); color: var(--accent); }
     .stack-toggle-btn .chevron { display:inline-block; width:10px; text-align:center; }
     .stack-content.collapsed { display:none; }
-    table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
+    table { width:100%; border-collapse: collapse; background: var(--bg-card-alt); border-radius:14px; overflow:hidden; table-layout: fixed; }
     th, td { padding:10px 12px; font-size:0.85rem; text-align:left; border-bottom:1px solid var(--border); vertical-align: middle; }
     th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
     tr:last-child td { border-bottom: none; }
@@ -139,7 +153,7 @@
     .checkmark { width:100%; height:100%; border-radius:6px; border:1px solid var(--border); display:inline-flex; align-items:center; justify-content:center; background: rgba(255,255,255,0.04); transition: all 0.15s ease; box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04); }
     .checkbox input:checked + .checkmark { background: var(--accent-gradient); border-color: rgba(49,196,255,0.8); box-shadow: 0 0 0 4px rgba(49,196,255,0.18); }
     .checkbox input:checked + .checkmark::after { content:'✓'; color:#0b111c; font-weight:900; font-size:0.85rem; }
-    .bulk-bar { position:fixed; left:0; right:0; bottom:0; background: var(--panel); border-top:1px solid var(--border); padding:12px 18px; display:none; align-items:center; justify-content:space-between; gap:12px; box-shadow: 0 -8px 20px rgba(0,0,0,0.25); z-index:30; color: var(--text); }
+    .bulk-bar { position:fixed; left:0; right:0; bottom:0; background: var(--bg-card); border-top:1px solid var(--border); padding:12px 18px; display:none; align-items:center; justify-content:space-between; gap:12px; box-shadow: 0 -8px 20px rgba(0,0,0,0.25); z-index:30; color: var(--text); }
     .bulk-bar.visible { display:flex; }
     .bulk-summary { color: var(--muted); font-weight:700; letter-spacing:0.02em; }
     .bulk-actions { display:flex; gap:8px; flex-wrap:wrap; }

--- a/d2ha/templates/events.html
+++ b/d2ha/templates/events.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Eventi</title>
   <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
+    :root {
+      --bg-base: #0b1020;
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(124,255,195,0.06), transparent 24%),
+                    linear-gradient(135deg, #0b1020, #10162c 60%, #0f1b3f 100%);
+      --bg-card: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)),
+                  rgba(17, 22, 36, 0.92);
+      --bg-card-alt: linear-gradient(160deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)),
+                     rgba(26, 34, 52, 0.86);
+      --accent-primary: #31c4ff;
+      --accent: var(--accent-primary);
       --accent-2: #7cffc3;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
       --accent-glow: rgba(49,196,255,0.35);
@@ -25,18 +32,26 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
-      --auth-bg-1: #0a1024;
-      --auth-bg-2: #0f1b3f;
+      --bg: var(--bg-base);
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
 
     body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
+      --bg-base: linear-gradient(135deg, #fff3e0, #ffe0c2);
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(255, 184, 94, 0.18), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(255, 129, 73, 0.16), transparent 24%),
+                    var(--bg-base);
+      --bg-card: linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.78)),
+                  linear-gradient(180deg, rgba(255, 138, 61, 0.12), rgba(255, 206, 115, 0.06)),
+                  #ffffff;
+      --bg-card-alt: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.84)),
+                     #fff7ed;
+      --accent-primary: #f97316;
+      --accent: var(--accent-primary);
       --accent-2: #fb923c;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow: rgba(249,115,22,0.28);
       --accent-glow-soft: rgba(249,115,22,0.18);
       --accent-border-strong: rgba(249,115,22,0.55);
       --accent-border: rgba(249,115,22,0.42);
@@ -46,26 +61,25 @@
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --header-bg: linear-gradient(90deg, #fff0e0, #ffe1bf);
+      --stack-header-bg: linear-gradient(135deg, #ffe8cc, #ffd6a5);
       --control-surface: #fffaf3;
       --auth-bg-1: #ffe9d6;
       --auth-bg-2: #ffd0a1;
+      --bg: #fff7ed;
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 10% 20%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 90% 10%, rgba(124,255,195,0.05), transparent 20%),
-                  var(--bg);
+      background: var(--bg-primary);
       color: var(--text);
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
-                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-primary);
       border-bottom: 1px solid var(--border);
       padding: 16px 18px;
       position: sticky;
@@ -75,9 +89,7 @@
       backdrop-filter: blur(6px);
     }
     .header-shell {
-      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
-                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: 18px;
       box-shadow: var(--shadow);
@@ -99,12 +111,12 @@
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
     .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display: flex; flex-direction: column; gap: 14px; }
-    .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
+    .card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:14px 16px; box-shadow: var(--shadow); }
     .filters { display:flex; gap:12px; align-items:center; flex-wrap:wrap; }
     .select, .input { background: var(--control-surface); color: var(--text); border:1px solid var(--border); border-radius:10px; padding:8px 10px; font-size:0.9rem; }
     .btn { border:none; border-radius:10px; padding:9px 14px; font-weight:700; cursor:pointer; background: var(--accent-gradient); color:#0c121e; box-shadow:0 6px 18px var(--accent-glow); }
     .table-card { padding:0; overflow:hidden; }
-    .table-head { display:flex; justify-content:space-between; align-items:center; padding:14px 16px; border-bottom:1px solid var(--border); background: rgba(255,255,255,0.02); flex-wrap:wrap; gap:10px; }
+    .table-head { display:flex; justify-content:space-between; align-items:center; padding:14px 16px; border-bottom:1px solid var(--border); background: var(--bg-card-alt); flex-wrap:wrap; gap:10px; }
     table { width:100%; border-collapse: collapse; }
     th, td { padding:10px 12px; text-align:left; font-size:0.85rem; border-bottom:1px solid var(--border); }
     th { color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }

--- a/d2ha/templates/home.html
+++ b/d2ha/templates/home.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Home</title>
   <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
+    :root {
+      --bg-base: #0b1020;
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(124,255,195,0.06), transparent 24%),
+                    linear-gradient(135deg, #0b1020, #10162c 60%, #0f1b3f 100%);
+      --bg-card: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)),
+                  rgba(17, 22, 36, 0.92);
+      --bg-card-alt: linear-gradient(160deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)),
+                     rgba(26, 34, 52, 0.86);
+      --accent-primary: #31c4ff;
+      --accent: var(--accent-primary);
       --accent-2: #7cffc3;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
       --accent-glow: rgba(49,196,255,0.35);
@@ -25,18 +32,26 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
-      --auth-bg-1: #0a1024;
-      --auth-bg-2: #0f1b3f;
+      --bg: var(--bg-base);
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
 
     body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
+      --bg-base: linear-gradient(135deg, #fff3e0, #ffe0c2);
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(255, 184, 94, 0.18), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(255, 129, 73, 0.16), transparent 24%),
+                    var(--bg-base);
+      --bg-card: linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.78)),
+                  linear-gradient(180deg, rgba(255, 138, 61, 0.12), rgba(255, 206, 115, 0.06)),
+                  #ffffff;
+      --bg-card-alt: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.84)),
+                     #fff7ed;
+      --accent-primary: #f97316;
+      --accent: var(--accent-primary);
       --accent-2: #fb923c;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow: rgba(249,115,22,0.28);
       --accent-glow-soft: rgba(249,115,22,0.18);
       --accent-border-strong: rgba(249,115,22,0.55);
       --accent-border: rgba(249,115,22,0.42);
@@ -46,26 +61,23 @@
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --header-bg: linear-gradient(90deg, #fff0e0, #ffe1bf);
+      --stack-header-bg: linear-gradient(135deg, #ffe8cc, #ffd6a5);
       --control-surface: #fffaf3;
-      --auth-bg-1: #ffe9d6;
-      --auth-bg-2: #ffd0a1;
+      --bg: #fff7ed;
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 10% 20%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 90% 10%, rgba(124,255,195,0.05), transparent 20%),
-                  var(--bg);
+      background: var(--bg-primary);
       color: var(--text);
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
-                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-primary);
       border-bottom: 1px solid var(--border);
       padding: 16px 18px;
       position: sticky;
@@ -75,9 +87,7 @@
       backdrop-filter: blur(6px);
     }
     .header-shell {
-      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
-                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: 18px;
       box-shadow: var(--shadow);
@@ -125,9 +135,9 @@
       min-height: calc(100vh - 110px);
     }
     aside {
-      background: var(--panel);
+      background: var(--bg-card);
       border: 1px solid var(--border);
-      border-radius: 14px;
+      border-radius: 18px;
       padding: 14px;
       box-shadow: var(--shadow);
     }
@@ -139,9 +149,9 @@
       color: var(--muted);
     }
     details {
-      background: var(--panel-2);
+      background: var(--bg-card-alt);
       border: 1px solid var(--border);
-      border-radius: 12px;
+      border-radius: 14px;
       margin-bottom: 10px;
       padding: 10px 12px;
       transition: border-color 0.15s ease;
@@ -180,7 +190,7 @@
       gap: 12px;
       padding: 10px 12px;
       border-radius: 10px;
-      background: rgba(255,255,255,0.03);
+      background: var(--bg-card-alt);
       border: 1px solid var(--border);
       font-size: 0.92rem;
       min-height: 56px;
@@ -201,7 +211,7 @@
       justify-content: center;
       border-radius: 8px;
       border: 1px solid var(--border);
-      background: rgba(255,255,255,0.04);
+      background: var(--bg-card-alt);
       color: var(--muted);
       transition: all 0.15s ease;
     }
@@ -269,9 +279,9 @@
       gap: 16px;
     }
     .card {
-      background: var(--panel);
+      background: var(--bg-card);
       border: 1px solid var(--border);
-      border-radius: 14px;
+      border-radius: 18px;
       padding: 14px 16px;
       box-shadow: var(--shadow);
     }
@@ -281,9 +291,9 @@
       gap: 12px;
     }
     .metric {
-      background: var(--panel-2);
+      background: var(--bg-card-alt);
       border: 1px solid var(--border);
-      border-radius: 12px;
+      border-radius: 14px;
       padding: 14px;
       display: flex;
       flex-direction: column;
@@ -313,9 +323,9 @@
       gap: 12px;
     }
     .tile {
-      background: var(--panel-2);
+      background: var(--bg-card-alt);
       border: 1px solid var(--border);
-      border-radius: 12px;
+      border-radius: 14px;
       padding: 12px;
     }
     .tile h3 { margin: 0 0 8px; font-size: 1rem; }

--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Immagini</title>
   <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
+    :root {
+      --bg-base: #0b1020;
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(124,255,195,0.06), transparent 24%),
+                    linear-gradient(135deg, #0b1020, #10162c 60%, #0f1b3f 100%);
+      --bg-card: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)),
+                  rgba(17, 22, 36, 0.92);
+      --bg-card-alt: linear-gradient(160deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)),
+                     rgba(26, 34, 52, 0.86);
+      --accent-primary: #31c4ff;
+      --accent: var(--accent-primary);
       --accent-2: #7cffc3;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
       --accent-glow: rgba(49,196,255,0.35);
@@ -25,18 +32,26 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
-      --auth-bg-1: #0a1024;
-      --auth-bg-2: #0f1b3f;
+      --bg: var(--bg-base);
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
 
     body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
+      --bg-base: linear-gradient(135deg, #fff3e0, #ffe0c2);
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(255, 184, 94, 0.18), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(255, 129, 73, 0.16), transparent 24%),
+                    var(--bg-base);
+      --bg-card: linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.78)),
+                  linear-gradient(180deg, rgba(255, 138, 61, 0.12), rgba(255, 206, 115, 0.06)),
+                  #ffffff;
+      --bg-card-alt: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.84)),
+                     #fff7ed;
+      --accent-primary: #f97316;
+      --accent: var(--accent-primary);
       --accent-2: #fb923c;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow: rgba(249,115,22,0.28);
       --accent-glow-soft: rgba(249,115,22,0.18);
       --accent-border-strong: rgba(249,115,22,0.55);
       --accent-border: rgba(249,115,22,0.42);
@@ -46,19 +61,20 @@
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --header-bg: linear-gradient(90deg, #fff0e0, #ffe1bf);
+      --stack-header-bg: linear-gradient(135deg, #ffe8cc, #ffd6a5);
       --control-surface: #fffaf3;
       --auth-bg-1: #ffe9d6;
       --auth-bg-2: #ffd0a1;
+      --bg: #fff7ed;
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
     * { box-sizing: border-box; }
-    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg-primary); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header {
-      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
-                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-primary);
       border-bottom:1px solid var(--border);
       padding:16px 18px;
       box-shadow: var(--shadow);
@@ -68,9 +84,7 @@
       backdrop-filter: blur(6px);
     }
     .header-shell {
-      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
-                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: 18px;
       box-shadow: var(--shadow);
@@ -91,8 +105,8 @@
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
     .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
-    .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
-    table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; }
+    .card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:14px 16px; box-shadow: var(--shadow); }
+    table { width:100%; border-collapse: collapse; background: var(--bg-card-alt); border-radius:14px; overflow:hidden; }
     th, td { padding:10px 12px; font-size:0.85rem; text-align:left; border-bottom:1px solid var(--border); vertical-align: middle; }
     th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
     tr:last-child td { border-bottom: none; }

--- a/d2ha/templates/security_settings.html
+++ b/d2ha/templates/security_settings.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Sicurezza</title>
   <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
+    :root {
+      --bg-base: #0b1020;
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(124,255,195,0.06), transparent 24%),
+                    linear-gradient(135deg, #0b1020, #10162c 60%, #0f1b3f 100%);
+      --bg-card: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)),
+                  rgba(17, 22, 36, 0.92);
+      --bg-card-alt: linear-gradient(160deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)),
+                     rgba(26, 34, 52, 0.86);
+      --accent-primary: #31c4ff;
+      --accent: var(--accent-primary);
       --accent-2: #7cffc3;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
       --accent-glow: rgba(49,196,255,0.35);
@@ -25,16 +32,26 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
+      --bg: var(--bg-base);
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
 
     body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
+      --bg-base: linear-gradient(135deg, #fff3e0, #ffe0c2);
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(255, 184, 94, 0.18), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(255, 129, 73, 0.16), transparent 24%),
+                    var(--bg-base);
+      --bg-card: linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.78)),
+                  linear-gradient(180deg, rgba(255, 138, 61, 0.12), rgba(255, 206, 115, 0.06)),
+                  #ffffff;
+      --bg-card-alt: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.84)),
+                     #fff7ed;
+      --accent-primary: #f97316;
+      --accent: var(--accent-primary);
       --accent-2: #fb923c;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow: rgba(249,115,22,0.28);
       --accent-glow-soft: rgba(249,115,22,0.18);
       --accent-border-strong: rgba(249,115,22,0.55);
       --accent-border: rgba(249,115,22,0.42);
@@ -44,23 +61,24 @@
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --header-bg: linear-gradient(90deg, #fff0e0, #ffe1bf);
+      --stack-header-bg: linear-gradient(135deg, #ffe8cc, #ffd6a5);
       --control-surface: #fffaf3;
+      --bg: #fff7ed;
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
     * { box-sizing: border-box; }
     body {
       margin: 0;
       font-family: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
-      background: radial-gradient(circle at 10% 20%, rgba(0,255,255,0.05), transparent 25%),
-                  radial-gradient(circle at 90% 10%, rgba(124,255,195,0.05), transparent 20%),
-                  var(--bg);
+      background: var(--bg-primary);
       color: var(--text);
       min-height: 100vh;
     }
     a { color: inherit; text-decoration: none; }
     header {
-      background: var(--header-bg);
+      background: var(--bg-primary);
       border-bottom: 1px solid var(--border);
       padding: 16px 22px 12px;
       position: sticky;
@@ -105,9 +123,9 @@
       gap: 14px;
     }
     .card {
-      background: var(--panel);
+      background: var(--bg-card);
       border: 1px solid var(--border);
-      border-radius: 14px;
+      border-radius: 18px;
       padding: 18px;
       box-shadow: var(--shadow);
     }

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -5,11 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>D2HA – Aggiornamenti</title>
   <style>
-                :root {
-      --bg: #0f1116;
-      --panel: #151924;
-      --panel-2: #1b2131;
-      --accent: #31c4ff;
+    :root {
+      --bg-base: #0b1020;
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(0,255,255,0.05), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(124,255,195,0.06), transparent 24%),
+                    linear-gradient(135deg, #0b1020, #10162c 60%, #0f1b3f 100%);
+      --bg-card: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
+                  linear-gradient(120deg, rgba(255,255,255,0.05), rgba(255,255,255,0.02)),
+                  rgba(17, 22, 36, 0.92);
+      --bg-card-alt: linear-gradient(160deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015)),
+                     rgba(26, 34, 52, 0.86);
+      --accent-primary: #31c4ff;
+      --accent: var(--accent-primary);
       --accent-2: #7cffc3;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
       --accent-glow: rgba(49,196,255,0.35);
@@ -25,18 +32,26 @@
       --header-bg: linear-gradient(90deg, #0d111c, #12182a);
       --stack-header-bg: linear-gradient(135deg, #141927, #0f131d);
       --control-surface: #0f141f;
-      --auth-bg-1: #0a1024;
-      --auth-bg-2: #0f1b3f;
+      --bg: var(--bg-base);
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
 
     body.theme-light {
-      --bg: #fff7ed;
-      --panel: #ffffff;
-      --panel-2: #fff3df;
-      --accent: #f97316;
+      --bg-base: linear-gradient(135deg, #fff3e0, #ffe0c2);
+      --bg-primary: radial-gradient(circle at 12% 18%, rgba(255, 184, 94, 0.18), transparent 26%),
+                    radial-gradient(circle at 84% 18%, rgba(255, 129, 73, 0.16), transparent 24%),
+                    var(--bg-base);
+      --bg-card: linear-gradient(150deg, rgba(255, 255, 255, 0.86), rgba(255, 255, 255, 0.78)),
+                  linear-gradient(180deg, rgba(255, 138, 61, 0.12), rgba(255, 206, 115, 0.06)),
+                  #ffffff;
+      --bg-card-alt: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.84)),
+                     #fff7ed;
+      --accent-primary: #f97316;
+      --accent: var(--accent-primary);
       --accent-2: #fb923c;
       --accent-gradient: linear-gradient(135deg, var(--accent), var(--accent-2));
-      --accent-glow: rgba(249,115,22,0.3);
+      --accent-glow: rgba(249,115,22,0.28);
       --accent-glow-soft: rgba(249,115,22,0.18);
       --accent-border-strong: rgba(249,115,22,0.55);
       --accent-border: rgba(249,115,22,0.42);
@@ -46,19 +61,20 @@
       --muted: #4b5563;
       --border: rgba(0,0,0,0.08);
       --shadow: 0 8px 24px rgba(0,0,0,0.1);
-      --header-bg: linear-gradient(90deg, #fff3df, #ffe8d5);
-      --stack-header-bg: linear-gradient(135deg, #fff3df, #ffe0c2);
+      --header-bg: linear-gradient(90deg, #fff0e0, #ffe1bf);
+      --stack-header-bg: linear-gradient(135deg, #ffe8cc, #ffd6a5);
       --control-surface: #fffaf3;
       --auth-bg-1: #ffe9d6;
       --auth-bg-2: #ffd0a1;
+      --bg: #fff7ed;
+      --panel: var(--bg-card);
+      --panel-2: var(--bg-card-alt);
     }
     * { box-sizing: border-box; }
-    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg); color: var(--text); }
+    body { margin:0; font-family:"Inter", system-ui, -apple-system, "Segoe UI", sans-serif; background: var(--bg-primary); color: var(--text); }
     a { color: inherit; text-decoration: none; }
     header {
-      background: radial-gradient(circle at 12% 18%, rgba(142, 232, 255, 0.06), transparent 26%),
-                  radial-gradient(circle at 84% 18%, rgba(124, 255, 195, 0.05), transparent 24%),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-primary);
       border-bottom:1px solid var(--border);
       padding:16px 18px;
       box-shadow: var(--shadow);
@@ -68,9 +84,7 @@
       backdrop-filter: blur(6px);
     }
     .header-shell {
-      background: linear-gradient(150deg, rgba(49, 196, 255, 0.12), rgba(124, 255, 195, 0.08)),
-                  linear-gradient(120deg, rgba(255,255,255,0.04), rgba(255,255,255,0.02)),
-                  linear-gradient(135deg, var(--auth-bg-1), var(--auth-bg-2));
+      background: var(--bg-card);
       border: 1px solid var(--border);
       border-radius: 18px;
       box-shadow: var(--shadow);
@@ -91,8 +105,8 @@
     .tab.active { background: var(--accent-gradient); color:#0c121e; box-shadow:0 10px 26px var(--accent-glow); border-color: var(--accent-border); }
     .logout-link { margin-left:auto; background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.06)); color: var(--text); box-shadow: inset 0 1px 0 rgba(255,255,255,0.08), 0 8px 20px rgba(0,0,0,0.35); border-color: var(--border); }
     main { padding: 18px; display:flex; flex-direction:column; gap:14px; }
-    .card { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:14px 16px; box-shadow: var(--shadow); }
-    table { width:100%; border-collapse: collapse; background: var(--panel-2); border-radius:12px; overflow:hidden; table-layout: fixed; }
+    .card { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:14px 16px; box-shadow: var(--shadow); }
+    table { width:100%; border-collapse: collapse; background: var(--bg-card-alt); border-radius:14px; overflow:hidden; table-layout: fixed; }
     th, td { padding:12px 12px; font-size:0.88rem; text-align:left; border-bottom:1px solid var(--border); vertical-align: middle; line-height: 1.4; }
     th { background: rgba(255,255,255,0.03); color: var(--muted); text-transform: uppercase; letter-spacing: 0.04em; font-size:0.8rem; }
     tr:last-child td { border-bottom: none; }
@@ -140,7 +154,7 @@
     .pill-row { display:flex; gap:6px; align-items:center; flex-wrap:wrap; }
     .confirm-backdrop { position:fixed; inset:0; background: rgba(0,0,0,0.65); display:none; align-items:center; justify-content:center; z-index:50; padding:18px; }
     .confirm-backdrop.visible { display:flex; }
-    .confirm-modal { background: var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px; width:min(420px, 100%); box-shadow: var(--shadow); display:flex; flex-direction:column; gap:12px; }
+    .confirm-modal { background: var(--bg-card); border:1px solid var(--border); border-radius:18px; padding:18px; width:min(420px, 100%); box-shadow: var(--shadow); display:flex; flex-direction:column; gap:12px; }
     .confirm-title { margin:0; font-size:1rem; }
     .confirm-actions { display:flex; justify-content:flex-end; gap:8px; }
     .btn-ghost { background: var(--control-surface); color: var(--text); border-color: var(--border); }


### PR DESCRIPTION
## Summary
- add shared design tokens for unified backgrounds and card surfaces across the dashboard
- align header, body, and panel styling in dark and light themes using login-inspired gradients
- apply consistent card radii and nested surface colors across dashboard-related templates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b8346978832d9817379f6ff80820)