### PR TITLE
Restore stack toggles on stack pages

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -386,14 +386,16 @@
     const deselectButtons = Array.from(document.querySelectorAll('.deselect-stack'));
     const autodiscoveryForm = document.getElementById('autodiscovery-form');
     stackToggles.forEach((header) => {
-      const btn = header.querySelector('.stack-toggle-btn');
+      const btn = header.querySelector('.section-toggle-btn, .stack-toggle-btn');
       const content = header.nextElementSibling;
+      const card = header.closest('.section-card');
       const chevron = btn ? btn.querySelector('.chevron') : null;
       if (!btn || !content) return;
 
       const setExpanded = (expanded) => {
         content.classList.toggle('collapsed', !expanded);
-        btn.setAttribute('aria-expanded', expanded);
+        if (card) card.classList.toggle('collapsed', !expanded);
+        btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         if (chevron) chevron.textContent = expanded ? '▾' : '▸';
       };
 

--- a/d2ha/templates/containers.html
+++ b/d2ha/templates/containers.html
@@ -648,14 +648,16 @@
   <script>
     const stackToggles = Array.from(document.querySelectorAll('[data-stack-toggle]'));
     stackToggles.forEach((header) => {
-      const btn = header.querySelector('.stack-toggle-btn');
+      const btn = header.querySelector('.section-toggle-btn, .stack-toggle-btn');
       const content = header.nextElementSibling;
+      const card = header.closest('.section-card');
       const chevron = btn ? btn.querySelector('.chevron') : null;
       if (!btn || !content) return;
 
       const setExpanded = (expanded) => {
         content.classList.toggle('collapsed', !expanded);
-        btn.setAttribute('aria-expanded', expanded);
+        if (card) card.classList.toggle('collapsed', !expanded);
+        btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
         if (chevron) chevron.textContent = expanded ? '▾' : '▸';
       };
 

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -456,13 +456,37 @@
     let refreshTimer = null;
     let autoScanEnabled = !(window.d2haSettings?.performanceMode);
 
-    function toggleStack(card) {
-      card.classList.toggle('collapsed');
-    }
+    const stackToggles = Array.from(document.querySelectorAll('[data-stack-toggle]'));
+    stackToggles.forEach((header) => {
+      const btn = header.querySelector('.section-toggle-btn, .stack-toggle-btn');
+      const content = header.nextElementSibling;
+      const card = header.closest('.section-card');
+      const chevron = btn ? btn.querySelector('.chevron') : null;
+      if (!btn || !content) return;
 
-    document.querySelectorAll('.stack-card').forEach(card => {
-      const header = card.querySelector('.stack-header');
-      header.addEventListener('click', () => toggleStack(card));
+      const setExpanded = (expanded) => {
+        content.classList.toggle('collapsed', !expanded);
+        if (card) card.classList.toggle('collapsed', !expanded);
+        btn.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+        if (chevron) chevron.textContent = expanded ? '▾' : '▸';
+      };
+
+      setExpanded(true);
+
+      const toggle = () => {
+        const isExpanded = btn.getAttribute('aria-expanded') === 'true';
+        setExpanded(!isExpanded);
+      };
+
+      btn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        toggle();
+      });
+
+      header.addEventListener('click', (event) => {
+        if (event.target === btn || btn.contains(event.target)) return;
+        toggle();
+      });
     });
 
     function applyStatus(row, state) {


### PR DESCRIPTION
## Summary
- fix stack toggle buttons on containers, updates, and autodiscovery pages by targeting the correct toggle controls
- ensure collapsed state updates both content and parent card for proper chevron rotation and visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924395621d8832d8ef55d7072fc0254)