### PR TITLE
Add startup splash screen with backend readiness check

### DIFF
--- a/d2ha/static/css/auth.css
+++ b/d2ha/static/css/auth.css
@@ -511,6 +511,134 @@ body.theme-light {
   margin: 0;
 }
 
+/* Splash screen */
+.splash-page {
+  min-height: 100vh;
+}
+
+.splash-overlay {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.splash-card {
+  width: min(560px, 100%);
+  padding: 28px 26px;
+  border-radius: 22px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, var(--accent-surface), rgba(124, 255, 195, 0.05)),
+    var(--panel);
+  border: 1px solid var(--accent-border-soft);
+  box-shadow: 0 14px 42px rgba(0, 0, 0, 0.38);
+  backdrop-filter: blur(12px) saturate(125%);
+  position: relative;
+  overflow: hidden;
+}
+
+.splash-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 18% 22%, rgba(124, 255, 195, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 30%, rgba(78, 201, 255, 0.12), transparent 36%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+.splash-header {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  padding: 10px 10px 22px;
+}
+
+.splash-logo-img {
+  width: 120px;
+  height: auto;
+  filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.4));
+}
+
+.splash-title {
+  margin: 10px 0 6px;
+  letter-spacing: 0.16em;
+  font-size: clamp(1.4rem, 2vw + 1rem, 2rem);
+  text-transform: uppercase;
+}
+
+.splash-subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.splash-progress {
+  position: relative;
+  z-index: 1;
+  margin-top: 10px;
+}
+
+.progress-track {
+  width: 100%;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--accent-border-soft);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-fill {
+  height: 100%;
+  background: var(--accent-gradient);
+  box-shadow: 0 0 16px var(--accent-glow);
+  border-radius: 999px;
+  transition: width 200ms ease;
+}
+
+.progress-shimmer {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent, rgba(255, 255, 255, 0.12), transparent);
+  animation: shimmer 1.8s infinite;
+}
+
+.progress-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+  color: var(--muted);
+}
+
+.progress-label {
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--text);
+}
+
+.progress-hint {
+  font-size: 0.95rem;
+}
+
+.splash-fade {
+  opacity: 0;
+  transition: opacity 450ms ease;
+}
+
+@keyframes shimmer {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 @media (max-width: 640px) {
   .auth-card {
     padding: 18px 16px;

--- a/d2ha/static/js/splash.js
+++ b/d2ha/static/js/splash.js
@@ -1,0 +1,67 @@
+(() => {
+  const config = window.d2haSplashConfig || {};
+  const targetUrl = config.targetUrl || '/login';
+  const healthUrl = config.healthUrl || '/api/health';
+  const progressFill = document.getElementById('progressFill');
+  const progressLabel = document.getElementById('progressLabel');
+  const page = document.querySelector('.splash-page');
+
+  if (!progressFill || !progressLabel) return;
+
+  let progress = 0;
+  let backendReady = false;
+  let finalizing = false;
+
+  const updateProgress = (value) => {
+    const clamped = Math.min(Math.max(value, 0), 100);
+    progressFill.style.width = `${clamped}%`;
+    progressLabel.textContent = `${Math.round(clamped)}%`;
+  };
+
+  const fadeOutAndRedirect = () => {
+    if (finalizing) return;
+    finalizing = true;
+    progress = 100;
+    updateProgress(progress);
+    if (page) {
+      page.classList.add('splash-fade');
+    }
+    setTimeout(() => {
+      window.location.assign(targetUrl);
+    }, 450);
+  };
+
+  const pollHealth = async () => {
+    try {
+      const response = await fetch(healthUrl, { cache: 'no-store' });
+      if (response.ok) {
+        const payload = await response.json();
+        backendReady = Boolean(payload.ready);
+      }
+    } catch (err) {
+      // ignore transient network errors during startup
+    }
+  };
+
+  const animate = () => {
+    if (backendReady) {
+      progress += (100 - progress) * 0.12;
+    } else {
+      const ceiling = 92;
+      progress += (ceiling - progress) * 0.08 + 0.15;
+    }
+
+    updateProgress(progress);
+
+    if (backendReady && progress >= 99.5) {
+      fadeOutAndRedirect();
+      return;
+    }
+
+    requestAnimationFrame(animate);
+  };
+
+  setInterval(pollHealth, 850);
+  pollHealth();
+  animate();
+})();

--- a/d2ha/templates/splash.html
+++ b/d2ha/templates/splash.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="{{ get_current_lang() }}">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>D2HA • Loading</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
+</head>
+<body class="theme-{{ get_current_theme() }}">
+  <div class="auth-page splash-page">
+    <canvas id="authCanvas" class="auth-canvas" aria-hidden="true"></canvas>
+    <div class="auth-title" aria-hidden="true">D2HA</div>
+    <div class="auth-logo" aria-hidden="true">
+      <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="D2HA Logo">
+    </div>
+
+    <div class="auth-overlay splash-overlay">
+      <div class="splash-card">
+        <div class="splash-header">
+          <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="D2HA Logo" class="splash-logo-img">
+          <h1 class="splash-title">D2HA</h1>
+          <p class="splash-subtitle">Preparing your dashboard...</p>
+        </div>
+
+        <div class="splash-progress" role="status" aria-live="polite">
+          <div class="progress-track">
+            <div class="progress-fill" id="progressFill" style="width: 0%"></div>
+            <div class="progress-shimmer"></div>
+          </div>
+          <div class="progress-info">
+            <span id="progressLabel" class="progress-label">0%</span>
+            <span class="progress-hint">Checking services & caching data</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>window.d2haSplashConfig = { targetUrl: "{{ target_url }}", healthUrl: "{{ url_for('api_health') }}" };</script>
+  <script src="{{ url_for('static', filename='js/auth_background.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/splash.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a splash template that reuses the auth look and shows animated startup progress
- introduce a health endpoint and middleware redirect to show the splash while the backend warms up
- animate a fade-out transition to login or the dashboard once the server reports ready

## Testing
- python -m compileall d2ha

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692441eb5f8c832d9a37f43c985b6d10)