### PR TITLE
Refine splash screen layout

### DIFF
--- a/d2ha/static/css/auth.css
+++ b/d2ha/static/css/auth.css
@@ -104,12 +104,12 @@ body.theme-light {
   left: 50%;
   transform: translateX(-50%);
   z-index: 3;
-  letter-spacing: 0.32em;
+  letter-spacing: 0.38em;
   text-transform: uppercase;
   color: #eaf6ff;
   font-weight: 800;
   text-shadow: 0 0 16px rgba(78, 201, 255, 0.48), 0 0 32px rgba(124, 255, 195, 0.32);
-  font-size: clamp(1.3rem, 2.2vw + 0.8rem, 1.9rem);
+  font-size: clamp(2rem, 3vw + 1.4rem, 3.2rem);
   opacity: 0.92;
   pointer-events: none;
 }
@@ -551,20 +551,17 @@ body.theme-light {
   position: relative;
   z-index: 1;
   text-align: center;
-  padding: 10px 10px 22px;
+  padding: 14px 10px 26px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
 }
 
 .splash-logo-img {
-  width: 120px;
+  width: clamp(150px, 20vw, 190px);
   height: auto;
   filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.4));
-}
-
-.splash-title {
-  margin: 10px 0 6px;
-  letter-spacing: 0.16em;
-  font-size: clamp(1.4rem, 2vw + 1rem, 2rem);
-  text-transform: uppercase;
 }
 
 .splash-subtitle {

--- a/d2ha/templates/splash.html
+++ b/d2ha/templates/splash.html
@@ -10,15 +10,11 @@
   <div class="auth-page splash-page">
     <canvas id="authCanvas" class="auth-canvas" aria-hidden="true"></canvas>
     <div class="auth-title" aria-hidden="true">D2HA</div>
-    <div class="auth-logo" aria-hidden="true">
-      <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="D2HA Logo">
-    </div>
 
     <div class="auth-overlay splash-overlay">
       <div class="splash-card">
         <div class="splash-header">
           <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="D2HA Logo" class="splash-logo-img">
-          <h1 class="splash-title">D2HA</h1>
           <p class="splash-subtitle">Preparing your dashboard...</p>
         </div>
 


### PR DESCRIPTION
## Summary
- Enlarged the splash hero title to emphasize the D2HA branding without altering existing behavior
- Removed the background logo element and simplified the card header to focus on the primary logo
- Increased and centered the main logo above the status text while keeping progress indicators unchanged

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244520c3ac832dbbd1c4feac8d6ea8)