### PR TITLE
Harden splash page JS output and overview refresher resiliency

### DIFF
--- a/d2ha/docker_service.py
+++ b/d2ha/docker_service.py
@@ -2,6 +2,7 @@ import json
 import os
 import threading
 import time
+import logging
 from collections import deque
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional
@@ -144,6 +145,7 @@ class AutodiscoveryPreferences:
 
 class DockerService:
     def __init__(self, remote_cache_ttl: int = 300, stats_cache_ttl: int = 2):
+        self.logger = logging.getLogger(__name__)
         self.docker_client = docker.from_env()
         self.docker_api = self.docker_client.api
         self.remote_cache: Dict[str, Dict[str, Any]] = {}
@@ -574,12 +576,11 @@ class DockerService:
             return
 
         def _run():
-            self.refresh_overview_cache()
             while True:
                 try:
                     self.refresh_overview_cache()
                 except Exception:
-                    pass
+                    self.logger.exception("Failed to refresh overview cache")
                 time.sleep(interval)
 
         thread = threading.Thread(target=_run, name="overview_refresher", daemon=True)

--- a/d2ha/templates/splash.html
+++ b/d2ha/templates/splash.html
@@ -32,7 +32,12 @@
     </div>
   </div>
 
-  <script>window.d2haSplashConfig = { targetUrl: "{{ target_url }}", healthUrl: "{{ url_for('api_health') }}" };</script>
+  <script>
+    window.d2haSplashConfig = {
+      targetUrl: {{ target_url | tojson }},
+      healthUrl: {{ url_for('api_health') | tojson }}
+    };
+  </script>
   <script src="{{ url_for('static', filename='js/auth_background.js') }}"></script>
   <script src="{{ url_for('static', filename='js/splash.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- JSON-encode splash page URLs before embedding them in inline JavaScript
- initialize a DockerService logger and keep the overview refresher loop running with error logging after failures

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692446e254ac832d8dc117de4083b366)