### PR TITLE
Update splash screen layout

### DIFF
--- a/d2ha/static/css/auth.css
+++ b/d2ha/static/css/auth.css
@@ -520,46 +520,28 @@ body.theme-light {
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
+  gap: 18px;
   min-height: 100vh;
-}
-
-.splash-card {
-  width: min(560px, 100%);
-  padding: 28px 26px;
-  border-radius: 22px;
-  background: linear-gradient(160deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
-    linear-gradient(180deg, var(--accent-surface), rgba(124, 255, 195, 0.05)),
-    var(--panel);
-  border: 1px solid var(--accent-border-soft);
-  box-shadow: 0 14px 42px rgba(0, 0, 0, 0.38);
-  backdrop-filter: blur(12px) saturate(125%);
-  position: relative;
-  overflow: hidden;
-}
-
-.splash-card::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 18% 22%, rgba(124, 255, 195, 0.08), transparent 35%),
-    radial-gradient(circle at 80% 30%, rgba(78, 201, 255, 0.12), transparent 36%);
-  opacity: 0.8;
-  pointer-events: none;
+  text-align: center;
+  width: min(640px, 92vw);
+  margin: 0 auto;
+  padding: 32px 12px;
 }
 
 .splash-header {
   position: relative;
   z-index: 1;
   text-align: center;
-  padding: 14px 10px 26px;
+  padding: 10px 8px 12px;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 14px;
+  gap: 12px;
 }
 
 .splash-logo-img {
-  width: clamp(150px, 20vw, 190px);
+  width: clamp(230px, 30vw, 340px);
   height: auto;
   filter: drop-shadow(0 10px 24px rgba(0, 0, 0, 0.4));
 }
@@ -573,7 +555,9 @@ body.theme-light {
 .splash-progress {
   position: relative;
   z-index: 1;
-  margin-top: 10px;
+  margin-top: 6px;
+  width: min(620px, 92vw);
+  align-self: stretch;
 }
 
 .progress-track {

--- a/d2ha/templates/splash.html
+++ b/d2ha/templates/splash.html
@@ -12,21 +12,19 @@
     <div class="auth-title" aria-hidden="true">D2HA</div>
 
     <div class="auth-overlay splash-overlay">
-      <div class="splash-card">
-        <div class="splash-header">
-          <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="D2HA Logo" class="splash-logo-img">
-          <p class="splash-subtitle">Preparing your dashboard...</p>
-        </div>
+      <div class="splash-header">
+        <img src="{{ url_for('static', filename='img/logo.svg') }}" alt="D2HA Logo" class="splash-logo-img">
+        <p class="splash-subtitle">Preparing your dashboard...</p>
+      </div>
 
-        <div class="splash-progress" role="status" aria-live="polite">
-          <div class="progress-track">
-            <div class="progress-fill" id="progressFill" style="width: 0%"></div>
-            <div class="progress-shimmer"></div>
-          </div>
-          <div class="progress-info">
-            <span id="progressLabel" class="progress-label">0%</span>
-            <span class="progress-hint">Checking services & caching data</span>
-          </div>
+      <div class="splash-progress" role="status" aria-live="polite">
+        <div class="progress-track">
+          <div class="progress-fill" id="progressFill" style="width: 0%"></div>
+          <div class="progress-shimmer"></div>
+        </div>
+        <div class="progress-info">
+          <span id="progressLabel" class="progress-label">0%</span>
+          <span class="progress-hint">Checking services & caching data</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove the framed card from the splash screen to let the content float on the backdrop
- enlarge the splash logo and center the stack with responsive widths

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692448108788832daa50251879807423)