### PR TITLE
Sync web logo with updated docs asset

### DIFF
--- a/d2ha/static/img/logo.svg
+++ b/d2ha/static/img/logo.svg
@@ -1,8 +1,43 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg id="Livello_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 200 200">
-  <!-- Generator: Adobe Illustrator 29.0.1, SVG Export Plug-In . SVG Version: 2.1.0 Build 192)  -->
-  <defs>
-    <style>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="Livello_1"
+   version="1.1"
+   viewBox="0 0 200 200"
+   sodipodi:docname="logo_1.svg"
+   inkscape:version="1.4.2 (f4327f4, 2025-05-13)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="4.1259681"
+     inkscape:cx="63.500249"
+     inkscape:cy="111.3678"
+     inkscape:window-width="2560"
+     inkscape:window-height="1369"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Livello_1" />
+  <defs
+     id="defs1">
+    <rect
+       x="-25.206206"
+       y="0.24236736"
+       width="64.227351"
+       height="90.403026"
+       id="rect10" />
+    <style
+       id="style1">
       .st0 {
         fill: #4f4f4f;
       }
@@ -47,34 +82,134 @@
         font-size: 20px;
         font-weight: 700;
       }
-    </style>
+    
+
+      .arcText {
+        fill: #5fb3a6;
+        font-size: 3.2px;
+        letter-spacing: 0.5px;
+      }
+</style>
+    <path
+       id="textCirclePath"
+       d="M 62.4,59.5 A 37.3,37.3 0 1 1 137.0,59.5 A 37.3,37.3 0 1 1 62.4,59.5"
+       fill="none" />
   </defs>
-  <path class="st3" d="M0,0"/>
-  <g class="st6">
-    <g class="st6">
-      <text class="st7" transform="translate(67.3 122.2)"><tspan x="0" y="0">arBorae</tspan></text>
+  <path
+     class="st3"
+     d="M -90.686001,-34.658533"
+     id="path1"
+     style="stroke-width:1.90014" />
+  <g
+     class="st6"
+     id="g2"
+     transform="matrix(1.9152921,0,0,1.8850953,-103.53147,-40.960084)">
+    <g
+       class="st6"
+       id="g1">
+      <text
+         class="st7"
+         transform="translate(67.3,122.2)"
+         id="text1"><tspan
+           x="0"
+           y="0"
+           id="tspan1">arBorae</tspan></text>
     </g>
   </g>
-  <path class="st8" d="M0,0"/>
-  <g>
-    <circle class="st4" cx="99.7" cy="59.5" r="32.3"/>
-    <g>
-      <g>
-        <line class="st2" x1="100" y1="44.3" x2="100" y2="73"/>
-        <line class="st2" x1="81" y1="64.3" x2="100.6" y2="73.8"/>
-        <line class="st2" x1="119" y1="64.3" x2="99.4" y2="73.8"/>
+  <path
+     class="st8"
+     d="M -90.686001,-34.658533"
+     id="path2"
+     style="stroke-width:1.90014" />
+  <g
+     id="g8"
+     transform="matrix(1.9152921,0,0,1.8850953,-90.686001,-34.658533)">
+    <circle
+       class="st4"
+       cx="99.699997"
+       cy="59.5"
+       r="32.299999"
+       id="circle2" />
+    <g
+       id="g7">
+      <g
+         id="g4">
+        <line
+           class="st2"
+           x1="100"
+           y1="44.299999"
+           x2="100"
+           y2="73"
+           id="line2" />
+        <line
+           class="st2"
+           x1="81"
+           y1="64.300003"
+           x2="100.6"
+           y2="73.800003"
+           id="line3" />
+        <line
+           class="st2"
+           x1="119"
+           y1="64.300003"
+           x2="99.400002"
+           y2="73.800003"
+           id="line4" />
       </g>
-      <g>
-        <circle class="st1" cx="100" cy="44.3" r="2.9"/>
-        <circle class="st1" cx="81" cy="64.3" r="2.9"/>
-        <circle class="st1" cx="119" cy="64.3" r="2.9"/>
+      <g
+         id="g6">
+        <circle
+           class="st1"
+           cx="100"
+           cy="44.299999"
+           r="2.9000001"
+           id="circle4" />
+        <circle
+           class="st1"
+           cx="81"
+           cy="64.300003"
+           r="2.9000001"
+           id="circle5" />
+        <circle
+           class="st1"
+           cx="119"
+           cy="64.300003"
+           r="2.9000001"
+           id="circle6" />
       </g>
     </g>
-    <path class="st0" d="M100,75.2h0c2.8,0,5,2.2,5,5v21.9c0,2.8-2.2,5-5,5h0c-2.8,0-5-2.2-5-5v-21.9c0-2.8,2.2-5,5-5Z"/>
+    <path
+       class="st0"
+       d="m 100,75.2 v 0 c 2.8,0 5,2.2 5,5 v 21.9 c 0,2.8 -2.2,5 -5,5 v 0 c -2.8,0 -5,-2.2 -5,-5 V 80.2 c 0,-2.8 2.2,-5 5,-5 z"
+       id="path7" />
   </g>
-  <g class="st6">
-    <g class="st6">
-      <text class="st5" transform="translate(3.1 129.2)"><tspan x="0" y="0">Adaptive Reconfigurable Backbone for Optimized Resource Automation and Energy Efficiency </tspan></text>
+  <g
+     class="st6"
+     id="g10"
+     transform="matrix(0,-1.867279,1.8479751,0,-9.7098694,265.73403)">
+    <g
+       class="st6"
+       id="g9">
+      <text
+         class="st5 arcText"
+         text-anchor="middle"
+         id="text8"
+         style="-inkscape-font-specification:'ArialMT, Arial, Normal';font-family:ArialMT, Arial;font-weight:normal;font-style:normal;font-stretch:normal;font-variant:normal;font-size:3.58886px;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0.5px;text-anchor:middle;isolation:isolate;fill:#5fb3a6"><textPath
+           xlink:href="#textCirclePath"
+           startOffset="50%"
+           id="textPath8">Adaptive Reconfigurable Backbone for Optimized Resource Automation and Energy Efficiency</textPath></text>
     </g>
   </g>
+  <text
+     xml:space="preserve"
+     id="text10"
+     style="font-size:5.33333px;text-align:start;writing-mode:lr-tb;direction:ltr;white-space:pre;shape-inside:url(#rect10);fill:#000000"
+     transform="matrix(1.9152921,0,0,1.8850953,-90.686001,-34.658533)" />
+  <rect
+     style="fill:#000000;stroke-width:1.90014"
+     id="rect11"
+     width="3.6106622"
+     height="1.2922677"
+     x="76.060921"
+     y="293.90051" />
 </svg>


### PR DESCRIPTION
## Summary
- replace the web static logo with the updated asset from `docs` so the webserver reflects the latest branding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692453071c44832da8e901db88fe676a)