### PR TITLE
Fix MQTT stack select toggles

### DIFF
--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -510,7 +510,7 @@
     deselectButtons.forEach((button) => {
       button.addEventListener('click', (event) => {
         event.stopPropagation();
-        const stackSection = button.closest('.stack');
+        const stackSection = button.closest('.section-card');
         if (!stackSection) return;
 
         const checkboxes = Array.from(stackSection.querySelectorAll('input[type="checkbox"]'));


### PR DESCRIPTION
## Summary
- fix MQTT autodiscovery select/deselect all action by targeting the correct section container

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69250fd7bdc48331bd975932cc519212)