### PR TITLE
Refresh container cache after container actions

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -1100,6 +1100,7 @@ def container_action(container_id, action):
     elif action == "delete":
         docker_service.remove_container(container_id)
 
+    docker_service.refresh_overview_cache()
     _publish_current_state()
 
     return redirect(url_for("containers_view"))
@@ -1109,6 +1110,7 @@ def container_action(container_id, action):
 @onboarding_required
 def container_full_update(container_id):
     docker_service.recreate_container_with_latest_image(container_id)
+    docker_service.refresh_overview_cache()
     _publish_current_state()
     return redirect(url_for("updates"))
 


### PR DESCRIPTION
## Summary
- refresh the container overview cache immediately after container actions to reflect status changes
- refresh the cache after full updates so the containers page shows the latest state without waiting for polling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256d4e53dc832dabd4f0c0c5e0ecc6)