### PR TITLE
Persist MQTT autodiscovery preferences across rebuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Popup di dettaglio con:
   - Modalità sicura / prestazioni tramite l'icona a forma di ingranaggio nell'header;
   - entità MQTT dalla pagina Autodiscovery.
 - La configurazione di sicurezza viene salvata nel file JSON `auth_config.json` (creato automaticamente con permessi ristretti al primo avvio). Per conservarla tra i rebuild puoi puntare il percorso con `D2HA_AUTH_CONFIG_PATH` (default `/app/data/auth_config.json`) e montare il volume `./data:/app/data` nel `docker-compose.yml`.
+- Le preferenze di autodiscovery MQTT vengono salvate in `autodiscovery_preferences.json` nello **stesso percorso** di `auth_config.json` (o nel path indicato da `D2HA_AUTODISCOVERY_PREFS_PATH`) così da restare persistenti quando monti il volume `./data:/app/data`.
 - Variabili utili:
   - `D2HA_SECRET_KEY` per impostare la chiave di sessione Flask (obbligatorio in produzione);
   - `D2HA_ADMIN_USERNAME` per personalizzare l'username iniziale prima del primo avvio.

--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -24,7 +24,12 @@ from flask import (
 )
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from auth_store import ensure_default_auth_config, load_auth_config, save_auth_config
+from auth_store import (
+    AUTH_CONFIG_PATH,
+    ensure_default_auth_config,
+    load_auth_config,
+    save_auth_config,
+)
 from docker_service import (
     AutodiscoveryPreferences,
     DockerService,
@@ -77,7 +82,13 @@ MQTT_STATE_INTERVAL = int(os.getenv("MQTT_STATE_INTERVAL", "5"))
 
 docker_service = DockerService()
 docker_service.start_overview_refresher()
-preferences_path = os.path.join(os.path.dirname(__file__), "autodiscovery_preferences.json")
+preferences_path = os.environ.get(
+    "D2HA_AUTODISCOVERY_PREFS_PATH",
+    os.path.join(
+        os.path.dirname(AUTH_CONFIG_PATH) or os.path.dirname(__file__),
+        "autodiscovery_preferences.json",
+    ),
+)
 autodiscovery_preferences = AutodiscoveryPreferences(preferences_path)
 mqtt_manager = MqttManager(
     docker_service=docker_service,


### PR DESCRIPTION
## Summary
- allow configuring the MQTT autodiscovery preferences file via `D2HA_AUTODISCOVERY_PREFS_PATH` and default it alongside the auth config for persistence
- document the new persistence path and environment variable in the README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692592dffbc4833184caa35048ebfe23)