### PR TITLE
Add debug mode indicator badge

### DIFF
--- a/d2ha/templates/layouts/auth_base.html
+++ b/d2ha/templates/layouts/auth_base.html
@@ -6,7 +6,12 @@
   <title>{% block title %}D2HA{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 </head>
-<body class="theme-{{ get_current_theme() }}">
+<body
+  class="theme-{{ get_current_theme() }}"
+  data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}"
+  data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}"
+  data-debug-mode="{{ '1' if debug_mode_enabled else '0' }}"
+>
   <div class="auth-page">
     <!-- Auth animated tech background (login + wizard) -->
     <canvas id="authCanvas" class="auth-canvas" aria-hidden="true"></canvas>

--- a/d2ha/templates/partials/notifications_panel.html
+++ b/d2ha/templates/partials/notifications_panel.html
@@ -16,6 +16,10 @@
         <circle cx="12" cy="20" r="1.25" fill="currentColor" />
       </svg>
     </div>
+    <div class="debug-indicator" data-debug-indicator title="{{ t('debug_mode.label') }}" aria-label="{{ t('debug_mode.label') }}">
+      <span class="debug-indicator-icon" aria-hidden="true">🐞</span>
+      <span class="debug-indicator-text">{{ t('debug_mode.label') }}</span>
+    </div>
     <div class="notif-area">
       <button class="notif-toggle" id="notifToggle" aria-expanded="false" aria-controls="notifPanel">
         <span class="notif-icon" aria-hidden="true">🔔</span>

--- a/d2ha/templates/partials/notifications_styles.html
+++ b/d2ha/templates/partials/notifications_styles.html
@@ -61,6 +61,25 @@
   }
   .notif-area,
   .settings-area { position: relative; display: flex; align-items: center; }
+  .debug-indicator {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    border-radius: 12px;
+    background: var(--control-surface);
+    border: 1px dashed var(--accent-border);
+    color: var(--accent);
+    box-shadow: var(--shadow);
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    line-height: 1;
+  }
+  .debug-indicator-icon { font-size: 1rem; line-height: 1; }
+  .debug-indicator-text { white-space: nowrap; }
+  body[data-debug-mode="1"] .debug-indicator { display: inline-flex; }
   .notif-toggle,
   .settings-toggle { gap: 8px; }
   .notif-icon,
@@ -83,6 +102,11 @@
     .header-bar { grid-template-columns: 1fr; text-align: center; gap: 10px; }
     .header-left, .header-right { justify-content: center; }
     .header-right { flex-wrap: wrap; }
+  }
+  body.theme-light .debug-indicator {
+    background: #fffaf3;
+    border-color: var(--accent-border);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
   }
   .backend-modal-backdrop {
     position: fixed;

--- a/d2ha/templates/splash.html
+++ b/d2ha/templates/splash.html
@@ -6,7 +6,12 @@
   <title>D2HA • Loading</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/auth.css') }}">
 </head>
-<body class="theme-{{ get_current_theme() }}">
+<body
+  class="theme-{{ get_current_theme() }}"
+  data-safe-mode="{{ '1' if safe_mode_enabled else '0' }}"
+  data-performance-mode="{{ '1' if performance_mode_enabled else '0' }}"
+  data-debug-mode="{{ '1' if debug_mode_enabled else '0' }}"
+>
   <div class="auth-page splash-page">
     <canvas id="authCanvas" class="auth-canvas" aria-hidden="true"></canvas>
     <div class="auth-title" aria-hidden="true">D2HA</div>


### PR DESCRIPTION
## Summary
- add a debug-mode badge near the header indicators that shows only when debug is enabled
- style the new badge for light and dark themes while keeping existing header aesthetics
- propagate debug-mode data attributes to all pages, including auth and splash layouts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692650716cd08331aaea5c108aea6432)