### PR TITLE
Add bulk removal for unused images

### DIFF
--- a/d2ha/templates/images.html
+++ b/d2ha/templates/images.html
@@ -119,6 +119,28 @@
     .btn:hover { background:#31394e; transform: translateY(-1px); }
     .btn-danger { background:#b71c1c; }
     .btn:disabled { opacity:0.4; cursor:not-allowed; transform:none; }
+    .btn-accent { background: var(--accent-gradient); color: #0c121e; box-shadow: 0 8px 20px var(--accent-glow); border: 1px solid var(--accent-border); }
+    .btn-accent:hover { background: var(--accent); }
+    .card-header { display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
+    .actions-row { display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
+    .debug-overlay { position:fixed; inset:0; padding:18px; display:none; align-items:center; justify-content:center; background:rgba(5,8,15,0.78); z-index:70; backdrop-filter: blur(4px); }
+    .debug-overlay.visible { display:flex; }
+    .debug-panel { width:min(1100px, 100%); background: var(--panel); border:1px solid var(--accent-border-soft); border-radius: 18px; box-shadow: var(--shadow); overflow:hidden; display:flex; flex-direction:column; gap:0; }
+    .debug-header { display:flex; align-items:center; justify-content:space-between; gap:12px; padding:14px 16px; background: var(--stack-header-bg); border-bottom: 1px solid var(--border); }
+    .debug-eyebrow { text-transform: uppercase; letter-spacing: 0.1em; font-size: 0.75rem; color: var(--muted); }
+    .debug-title { font-weight: 800; font-size: 1.05rem; letter-spacing: 0.02em; }
+    .debug-actions { display:flex; gap:8px; align-items:center; }
+    .debug-body { display:grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap:12px; padding:14px 16px 18px; background: var(--panel-2); }
+    .debug-column { background: rgba(255,255,255,0.02); border:1px solid var(--border); border-radius: 14px; padding:12px; box-shadow: inset 0 1px 0 rgba(255,255,255,0.04); display:flex; flex-direction:column; gap:10px; min-height: 240px; }
+    .debug-subtitle { font-weight: 800; letter-spacing: 0.02em; text-transform: uppercase; font-size: 0.8rem; color: var(--muted); }
+    .debug-list, .debug-log { flex:1; overflow-y:auto; background: var(--control-surface); border-radius: 10px; padding:10px; border:1px dashed var(--accent-border-soft); font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 0.9rem; }
+    .debug-log-line { padding:6px 8px; border-bottom: 1px solid rgba(255,255,255,0.04); display:flex; gap:8px; align-items:flex-start; }
+    .debug-log-line:last-child { border-bottom:none; }
+    .debug-log-line .tag { padding:2px 6px; border-radius:8px; font-size:0.75rem; background: var(--accent-surface); color: var(--accent); border:1px solid var(--accent-border-soft); }
+    .debug-log-line .text { flex:1; word-break: break-word; }
+    .debug-list .command { padding:6px 8px; border-bottom:1px solid rgba(255,255,255,0.06); color: var(--text); }
+    .debug-list .command:last-child { border-bottom:none; }
+    .debug-overlay [class*='btn'] { background: var(--accent-surface); border:1px solid var(--accent-border-soft); color: var(--accent); }
     @media(max-width: 960px) {
       table, thead, tbody, th, td, tr { display:block; }
       thead { display:none; }
@@ -149,7 +171,14 @@
 
   <main>
     <div class="card">
-      <div class="meta">Totale immagini: {{ images|length }} · Container attivi: {{ summary.running }}</div>
+      <div class="card-header">
+        <div class="meta">Totale immagini: {{ images|length }} · Container attivi: {{ summary.running }}</div>
+        <div class="actions-row">
+          <form id="delete-unused-form" method="post" action="{{ url_for('delete_unused_images') }}" data-safe-confirm="Eliminare tutte le immagini non utilizzate?" data-safe-modal="external">
+            <button class="btn btn-accent" type="submit" id="delete-unused-btn">Elimina immagini non in uso</button>
+          </form>
+        </div>
+      </div>
     </div>
     <section class="card">
       <table>
@@ -191,6 +220,164 @@
       </table>
     </section>
   </main>
+  <div class="debug-overlay" id="debug-overlay" aria-hidden="true">
+    <div class="debug-panel">
+      <div class="debug-header">
+        <div>
+          <div class="debug-eyebrow">Debug live</div>
+          <div class="debug-title" id="debug-title">Eliminazione immagini</div>
+        </div>
+        <div class="debug-actions">
+          <button class="btn" type="button" id="debug-clear">Pulisci</button>
+          <button class="btn" type="button" id="debug-close">Chiudi</button>
+        </div>
+      </div>
+      <div class="debug-body">
+        <div class="debug-column">
+          <div class="debug-subtitle">Comandi</div>
+          <div class="debug-list" id="debug-commands"></div>
+        </div>
+        <div class="debug-column">
+          <div class="debug-subtitle">Log live</div>
+          <div class="debug-log" id="debug-logs"></div>
+        </div>
+      </div>
+    </div>
+  </div>
   {% include 'partials/notifications_script.html' %}
+  <script>
+    const deleteUnusedForm = document.getElementById('delete-unused-form');
+    const deleteUnusedBtn = document.getElementById('delete-unused-btn');
+    const debugOverlay = document.getElementById('debug-overlay');
+    const debugTitle = document.getElementById('debug-title');
+    const debugCommands = document.getElementById('debug-commands');
+    const debugLogs = document.getElementById('debug-logs');
+    const debugClose = document.getElementById('debug-close');
+    const debugClear = document.getElementById('debug-clear');
+    const debugEnabled = document.body.dataset.debugMode === '1';
+    const debugStreamSupported = debugEnabled && typeof EventSource !== 'undefined';
+    let activeDebugStream = null;
+
+    const safeParseEvent = (evt) => {
+      try { return JSON.parse(evt.data); }
+      catch (e) { return {}; }
+    };
+
+    const clearDebugOverlay = () => {
+      if (!debugCommands || !debugLogs) return;
+      debugCommands.innerHTML = '';
+      debugLogs.innerHTML = '';
+    };
+
+    const openDebugOverlay = (title) => {
+      if (!debugStreamSupported || !debugOverlay) return;
+      clearDebugOverlay();
+      if (debugTitle) debugTitle.textContent = title;
+      debugOverlay.classList.add('visible');
+      debugOverlay.setAttribute('aria-hidden', 'false');
+    };
+
+    const closeDebugOverlay = () => {
+      if (activeDebugStream) {
+        activeDebugStream.close();
+        activeDebugStream = null;
+      }
+      if (!debugOverlay) return;
+      debugOverlay.classList.remove('visible');
+      debugOverlay.setAttribute('aria-hidden', 'true');
+    };
+
+    const pushCommand = (text) => {
+      if (!debugEnabled || !debugCommands) return;
+      const row = document.createElement('div');
+      row.className = 'command';
+      row.textContent = text;
+      debugCommands.appendChild(row);
+      debugCommands.scrollTop = debugCommands.scrollHeight;
+    };
+
+    const pushLog = (text, tag = 'LOG') => {
+      if (!debugEnabled || !debugLogs) return;
+      const row = document.createElement('div');
+      row.className = 'debug-log-line';
+      const badge = document.createElement('span');
+      badge.className = 'tag';
+      badge.textContent = tag;
+      const body = document.createElement('span');
+      body.className = 'text';
+      body.textContent = text;
+      row.appendChild(badge);
+      row.appendChild(body);
+      debugLogs.appendChild(row);
+      debugLogs.scrollTop = debugLogs.scrollHeight;
+    };
+
+    const startDeleteUnusedStream = () => {
+      if (!debugStreamSupported) return Promise.reject(new Error('Debug non attivo'));
+      openDebugOverlay('Elimina immagini non in uso');
+      pushCommand('Richiesta di eliminazione immagini non utilizzate');
+
+      return new Promise((resolve, reject) => {
+        const source = new EventSource('/api/images/delete_unused/stream');
+        activeDebugStream = source;
+        let lastResult = null;
+        let ended = false;
+
+        source.addEventListener('command', (evt) => {
+          const data = safeParseEvent(evt);
+          if (data?.message) pushCommand(data.message);
+        });
+
+        source.addEventListener('log', (evt) => {
+          const data = safeParseEvent(evt);
+          if (data?.message) pushLog(data.message, 'LOG');
+        });
+
+        source.addEventListener('result', (evt) => {
+          const data = safeParseEvent(evt);
+          lastResult = data;
+        });
+
+        source.addEventListener('error', (evt) => {
+          const data = safeParseEvent(evt);
+          const msg = data?.message || 'Stream interrotto';
+          pushLog(msg, 'ERR');
+          source.close();
+          activeDebugStream = null;
+          if (!ended) reject(new Error(msg));
+        });
+
+        source.addEventListener('end', (evt) => {
+          ended = true;
+          pushLog('Pulizia completata', 'DONE');
+          source.close();
+          activeDebugStream = null;
+          resolve(lastResult || safeParseEvent(evt));
+          setTimeout(() => window.location.reload(), 800);
+        });
+      });
+    };
+
+    deleteUnusedForm?.addEventListener('submit', (event) => {
+      const confirmed = confirm('Eliminare tutte le immagini non utilizzate?');
+      if (!confirmed) {
+        event.preventDefault();
+        return;
+      }
+
+      if (debugStreamSupported) {
+        event.preventDefault();
+        startDeleteUnusedStream().catch(() => {
+          deleteUnusedForm.submit();
+        });
+      }
+    });
+
+    debugClose?.addEventListener('click', closeDebugOverlay);
+    debugClear?.addEventListener('click', clearDebugOverlay);
+    debugOverlay?.addEventListener('click', (evt) => {
+      if (evt.target === debugOverlay) closeDebugOverlay();
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Docker service helpers and API endpoints to find and delete unused images in bulk
- expose a new images page action with a debug overlay to stream deletion commands
- refresh the UI styling to surface the bulk "Elimina immagini non in uso" control

## Testing
- python -m compileall d2ha


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692656d3cb588331adebdfedacb61586)