### PR TITLE
Add MQTT delete-unused images action preference

### DIFF
--- a/d2ha/app.py
+++ b/d2ha/app.py
@@ -1139,6 +1139,12 @@ def autodiscovery_view():
     stable_ids = [c.get("stable_id", "") for c in containers_info]
 
     if request.method == "POST":
+        global_preferences = {
+            "delete_unused_images": request.form.get("delete_unused_images")
+            == "on"
+        }
+        autodiscovery_preferences.set_global_preferences(global_preferences)
+
         for c in containers_info:
             stable_id = c.get("stable_id")
             if not stable_id:
@@ -1161,6 +1167,7 @@ def autodiscovery_view():
     stack_map = {k: stack_map[k] for k in sorted(stack_map.keys())}
 
     pref_map = autodiscovery_preferences.build_map_for(stable_ids)
+    global_preferences = autodiscovery_preferences.get_global_preferences()
     stacks, summary = _build_home_context()
     notifications = _build_notifications_summary()
 
@@ -1178,6 +1185,7 @@ def autodiscovery_view():
         stack_map=stack_map,
         preferences=pref_map,
         actions=AutodiscoveryPreferences.AVAILABLE_ACTIONS,
+        global_preferences=global_preferences,
         summary=summary,
         notifications=notifications,
         active_page="autodiscovery",

--- a/d2ha/templates/autodiscovery.html
+++ b/d2ha/templates/autodiscovery.html
@@ -439,6 +439,23 @@
     </section>
 
     <form id="autodiscovery-form" class="stacks" method="POST">
+      <section class="section-card">
+        <div class="section-card-header">
+          <div class="title">
+            <span>Azioni generali</span>
+          </div>
+        </div>
+        <div class="section-card-body">
+          <div class="checkbox-row">
+            <label class="checkbox-item" title="Esponi su MQTT il bottone per cancellare le immagini non in uso">
+              <input type="checkbox" name="delete_unused_images" aria-label="Esponi su MQTT il bottone cancella immagini non in uso" {% if global_preferences.get('delete_unused_images') %}checked{% endif %} />
+              <span class="checkbox-label">Bottone "Cancella immagini non in uso"</span>
+            </label>
+          </div>
+          <div class="muted">Rende disponibile su MQTT il comando per eliminare le immagini Docker non utilizzate.</div>
+        </div>
+      </section>
+
       {% for stack, containers in stack_map.items() %}
         <section class="section-card">
           <div class="section-card-header section-toggle" data-stack-toggle>


### PR DESCRIPTION
## Summary
- add global MQTT preference to expose a button that deletes unused images
- publish a Docker-level MQTT button when enabled and handle incoming commands
- surface the new preference as a checkbox in the MQTT entities page

## Testing
- python -m compileall d2ha

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69265bbf27788331b1afe9de13d1877e)