### PR TITLE
Feature/update progress

### DIFF
--- a/d2ha/.dockerignore
+++ b/d2ha/.dockerignore
@@ -1,0 +1,8 @@
+# Keep secrets, runtime data and build cruft out of the image
+__pycache__/
+*.pyc
+.venv/
+auth_config.json
+autodiscovery_preferences.json
+data/
+.env

--- a/d2ha/routes/api.py
+++ b/d2ha/routes/api.py
@@ -1,3 +1,5 @@
+import queue
+import threading
 from typing import Any, Dict, List
 from flask import Blueprint, Response, current_app, jsonify, request, stream_with_context
 from .auth import onboarding_required, _publish_current_state
@@ -311,6 +313,70 @@ def api_container_full_update(container_id):
             "error": str(exc) or "Update failed",
             "container_id": container_id,
         }), 500
+
+
+@api_bp.route("/containers/<container_id>/full_update/stream", methods=["GET"])
+@onboarding_required
+def api_container_full_update_stream(container_id):
+    """Full container update streamed as SSE progress events (no debug mode required).
+
+    The actual update runs in a background thread decoupled from the SSE
+    connection, so a client disconnect mid-pull never leaves the container
+    removed-but-not-recreated.
+    """
+    docker_service = current_app.docker_service
+    mqtt_manager = current_app.mqtt_manager
+
+    container_info = _find_container_overview_entry(container_id)
+    if container_info and mqtt_manager.is_self_container(container_info):
+        return jsonify({
+            "error": "Non è possibile aggiornare questo container (Docker2HomeAssistant) dall'interfaccia. Usa docker pull / docker compose up -d.",
+            "container_id": container_id,
+        }), 400
+
+    app_obj = current_app._get_current_object()
+    events: "queue.Queue" = queue.Queue()
+
+    def worker():
+        new_id = container_id
+        with app_obj.app_context():
+            try:
+                for event in docker_service.iter_recreate_container_with_latest_image(container_id):
+                    if event.get("phase") == "done" and event.get("new_container_id"):
+                        new_id = event["new_container_id"]
+                    events.put(("progress", event))
+                try:
+                    docker_service.refresh_overview_cache()
+                    _publish_current_state()
+                except Exception:
+                    app_obj.logger.exception("Post-update refresh failed for %s", new_id)
+                result = _find_container_overview_entry(new_id)
+                events.put(("result", {
+                    "success": True,
+                    "container_id": new_id,
+                    "old_container_id": container_id,
+                    "container": result,
+                }))
+            except Exception as exc:
+                app_obj.logger.exception("Streamed full update failed for %s", container_id)
+                events.put(("fail", {"message": str(exc) or "Update failed", "container_id": container_id}))
+            finally:
+                events.put(("end", {"container_id": new_id}))
+                events.put(None)
+
+    threading.Thread(target=worker, name=f"full-update-{container_id[:12]}", daemon=True).start()
+
+    def generate():
+        while True:
+            item = events.get()
+            if item is None:
+                break
+            event_type, data = item
+            yield _sse_event(event_type, data)
+
+    headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+    return Response(stream_with_context(generate()), mimetype="text/event-stream", headers=headers)
+
 
 @api_bp.route("/containers/<container_id>/<action>", methods=["POST"])
 @onboarding_required

--- a/d2ha/services/docker/images_updates.py
+++ b/d2ha/services/docker/images_updates.py
@@ -20,11 +20,12 @@ from ..utils import build_stable_id, format_timedelta, human_bytes
 
 class DockerImagesUpdatesMixin:
     def _extract_version(self, labels: dict) -> Optional[str]:
+        # Note: org.opencontainers.image.revision is intentionally excluded — it is
+        # a VCS commit SHA, not a human version, and showing it as "version" misleads.
         for key in (
             "io.hass.version",
             "org.opencontainers.image.version",
             "version",
-            "org.opencontainers.image.revision",
         ):
             val = labels.get(key)
             if val:
@@ -141,7 +142,11 @@ class DockerImagesUpdatesMixin:
                 "Accept": "application/vnd.github.v3+json",
                 "User-Agent": "Docker2HomeAssistant/1.0"
             }
-            
+            # Optional token lifts the unauthenticated 60 req/hour limit to 5000.
+            gh_token = os.environ.get("D2HA_GITHUB_TOKEN", "").strip()
+            if gh_token:
+                headers["Authorization"] = f"Bearer {gh_token}"
+
             response = requests.get(url, headers=headers, timeout=10)
             if response.status_code == 200:
                 releases = response.json()
@@ -327,7 +332,6 @@ class DockerImagesUpdatesMixin:
             annotations.get("io.hass.version")
             or annotations.get("org.opencontainers.image.version")
             or annotations.get("version")
-            or annotations.get("org.opencontainers.image.revision")
             or reference_tag
             or remote_short
         )
@@ -599,13 +603,60 @@ class DockerImagesUpdatesMixin:
 
         return clean_tag
 
-    def recreate_container_with_latest_image(self, container_id: str):
-        self.logger.info("Starting full update for container %s", container_id)
+    @staticmethod
+    def _aggregate_pull_progress(line: Dict[str, Any], layers: Dict[str, Dict[str, int]]) -> Dict[str, Any]:
+        """Fold one `docker pull` stream line into the aggregate progress state.
 
-        # Step 1: Get container info before stopping it
+        Returns a progress event dict (overall downloaded/total bytes + percent).
+        `force` is set on layer status transitions so callers can emit promptly.
+        """
+        status = (line.get("status") or "").strip()
+        layer_id = line.get("id")
+        detail = line.get("progressDetail") or {}
+        force = False
+
+        if layer_id:
+            entry = layers.setdefault(layer_id, {"current": 0, "total": 0, "status": ""})
+            if entry["status"] != status:
+                entry["status"] = status
+                force = True
+            if detail.get("total"):
+                entry["total"] = int(detail.get("total") or entry["total"])
+                entry["current"] = int(detail.get("current") or entry["current"])
+            elif status in ("Pull complete", "Already exists", "Download complete"):
+                if entry["total"]:
+                    entry["current"] = entry["total"]
+
+        total = sum(l["total"] for l in layers.values())
+        current = sum(min(l["current"], l["total"]) for l in layers.values() if l["total"])
+        percent = round(current / total * 100) if total else None
+
+        message = status if not layer_id else f"{status} {layer_id[:12]}".strip()
+        return {
+            "phase": "pull",
+            "status": status,
+            "layer": layer_id,
+            "current": current,
+            "total": total,
+            "percent": percent,
+            "layers": len(layers),
+            "message": message,
+            "force": force,
+        }
+
+    def iter_recreate_container_with_latest_image(self, container_id: str) -> Iterable[Dict[str, Any]]:
+        """Full container update as a generator of progress events.
+
+        Each yielded item is a dict with a ``phase`` key. The terminal event has
+        phase ``done`` and a ``new_container_id``. Errors are raised (callers wrap
+        and surface them). The blocking :meth:`recreate_container_with_latest_image`
+        is a thin wrapper that drains this generator.
+        """
+        self.logger.info("Starting full update for container %s", container_id)
+        yield {"phase": "start", "message": "Avvio aggiornamento…"}
+
         try:
             c = self.docker_client.containers.get(container_id)
-            self.logger.debug("Found container: %s", c.name)
         except Exception as e:
             self.logger.warning("Container not found: %s", container_id)
             raise RuntimeError(f"Container non trovato: {container_id}") from e
@@ -620,59 +671,53 @@ class DockerImagesUpdatesMixin:
         host_config = attrs.get("HostConfig", {}) or {}
         networks = attrs.get("NetworkSettings", {}).get("Networks", {}) or {}
 
-        self.logger.debug(
-            "Container: %s | image ref: %s | current image ID: %s",
-            name, image_ref, old_image_id,
-        )
+        yield {"phase": "inspect", "message": f"Container «{name}»", "image_ref": image_ref}
 
-        # Step 2: STOP AND REMOVE the container FIRST
+        # Stop and remove the existing container first.
+        yield {"phase": "stopping", "message": "Arresto e rimozione del container…"}
         try:
-            self.logger.debug("Stopping and removing container: %s", name)
             self.docker_api.remove_container(c.id, force=True)
-            self.logger.debug("Container removed")
         except Exception as e:
             self.logger.error("Remove container failed: %s", e)
             raise RuntimeError(f"Errore nella rimozione del container {name}: {e}") from e
 
-        # Step 3: NOW we can remove the image tag to force fresh pull
+        # Drop the old image tag to force a fresh pull.
+        yield {"phase": "cleanup", "message": "Rimozione vecchia immagine…"}
         try:
-            self.logger.debug("Removing old image tag: %s", image_ref)
             self.docker_api.remove_image(image_ref, force=False, noprune=True)
-            self.logger.debug("Old image tag removed - will force fresh pull")
         except Exception as untag_err:
-            self.logger.debug("Could not remove image tag (will try pull anyway): %s", untag_err)
+            self.logger.debug("Could not remove image tag (will pull anyway): %s", untag_err)
 
-        # Step 4: Pull fresh image
+        # Pull the fresh image, streaming layer download progress.
+        yield {"phase": "pull", "message": f"Scaricamento immagine {image_ref}…", "percent": 0}
+        layers: Dict[str, Dict[str, int]] = {}
+        last_emit = 0.0
         try:
-            self.logger.debug("Pulling fresh image: %s", image_ref)
-
             for line in self.docker_api.pull(image_ref, stream=True, decode=True):
-                status = line.get("status", "")
-                progress = line.get("progress", "")
-                if status and ("Pulling" in status or "Downloading" in status
-                               or "Extracting" in status or "Pull complete" in status):
-                    self.logger.debug("%s %s", status, progress)
-
+                if line.get("error"):
+                    raise RuntimeError(line.get("error"))
+                event = self._aggregate_pull_progress(line, layers)
+                now = time.time()
+                if event["force"] or now - last_emit >= 0.2:
+                    last_emit = now
+                    yield event
             pulled_image = self.docker_client.images.get(image_ref)
             new_image_id = pulled_image.id if pulled_image else "unknown"
-            self.logger.debug("Pulled image ID: %s", new_image_id)
-
-            if old_image_id and new_image_id == old_image_id:
-                self.logger.info("No update available on registry for %s (same image ID)", name)
-            else:
-                self.logger.info(
-                    "New image downloaded for %s (old: %s, new: %s)",
-                    name, old_image_id[:19] if old_image_id else "none", new_image_id[:19],
-                )
         except Exception as e:
             self.logger.error("Pull failed: %s", e)
             raise RuntimeError(f"Errore nel pull dell'immagine {image_ref}: {e}") from e
 
-        # Step 5: Create and start new container
-        networking_config = None
-        if networks:
-            networking_config = {"EndpointsConfig": networks}
+        same_image = bool(old_image_id and new_image_id == old_image_id)
+        yield {
+            "phase": "pulled",
+            "percent": 100,
+            "same_image": same_image,
+            "message": "Immagine già all'ultima versione" if same_image else "Immagine scaricata",
+        }
 
+        # Recreate and start the container with the freshly pulled image.
+        yield {"phase": "recreate", "message": "Creazione e avvio del nuovo container…"}
+        networking_config = {"EndpointsConfig": networks} if networks else None
         create_kwargs: Dict[str, Any] = {
             "image": image_ref,
             "name": name,
@@ -684,29 +729,34 @@ class DockerImagesUpdatesMixin:
             "working_dir": config.get("WorkingDir"),
             "user": config.get("User"),
         }
-
         if config.get("Volumes"):
             create_kwargs["volumes"] = list(config["Volumes"].keys())
-
         if networking_config:
             create_kwargs["networking_config"] = networking_config
 
         try:
-            self.logger.debug("Creating new container: %s", name)
             new_container = self.docker_api.create_container(**create_kwargs)
             new_container_id = new_container.get("Id")
-
             self.docker_api.start(new_container_id)
-            self.logger.info("Container %s started successfully", name)
-
-            # Verify
-            new_c = self.docker_client.containers.get(new_container_id)
-            self.logger.debug("Verification - container image: %s", new_c.image.id[:19])
             self.logger.info("Full update completed for %s", name)
-            return new_container_id
         except Exception as e:
             self.logger.error("Create/start failed: %s", e)
             raise RuntimeError(f"Errore nella creazione/avvio del container {name}: {e}") from e
+
+        yield {
+            "phase": "done",
+            "message": "Aggiornamento completato",
+            "new_container_id": new_container_id,
+            "same_image": same_image,
+        }
+
+    def recreate_container_with_latest_image(self, container_id: str):
+        """Blocking full update; returns the new container id (drains the generator)."""
+        new_container_id = None
+        for event in self.iter_recreate_container_with_latest_image(container_id):
+            if event.get("phase") == "done":
+                new_container_id = event.get("new_container_id")
+        return new_container_id
 
     def list_images_overview(self) -> List[Dict[str, Any]]:
         containers = self.docker_client.containers.list(all=True)

--- a/d2ha/templates/partials/updates_script.html
+++ b/d2ha/templates/partials/updates_script.html
@@ -20,66 +20,9 @@ const statusClasses = {
     let refreshIntervalMs = pollingDefaults.intervalMs;
     let refreshTimer = null;
     let autoScanEnabled = !(window.d2haSettings?.performanceMode);
-    const debugOverlay = document.getElementById('debug-overlay');
-    const debugTitle = document.getElementById('debug-title');
-    const debugCommands = document.getElementById('debug-commands');
-    const debugLogs = document.getElementById('debug-logs');
-    const debugClose = document.getElementById('debug-close');
-    const debugClear = document.getElementById('debug-clear');
-    const debugEnabled = document.body.dataset.debugMode === '1';
-    const debugStreamSupported = debugEnabled && typeof EventSource !== 'undefined';
-    let activeDebugStream = null;
-
     const safeParseEvent = (evt) => {
       try { return JSON.parse(evt.data); }
       catch (e) { return {}; }
-    };
-
-    const clearDebugOverlay = () => {
-      debugCommands.innerHTML = '';
-      debugLogs.innerHTML = '';
-    };
-
-    const openDebugOverlay = (title) => {
-      if (!debugStreamSupported) return;
-      clearDebugOverlay();
-      debugTitle.textContent = title;
-      debugOverlay.classList.add('visible');
-      debugOverlay.setAttribute('aria-hidden', 'false');
-    };
-
-    const closeDebugOverlay = () => {
-      if (activeDebugStream) {
-        activeDebugStream.close();
-        activeDebugStream = null;
-      }
-      debugOverlay.classList.remove('visible');
-      debugOverlay.setAttribute('aria-hidden', 'true');
-    };
-
-    const pushCommand = (text) => {
-      if (!debugEnabled) return;
-      const row = document.createElement('div');
-      row.className = 'command';
-      row.textContent = text;
-      debugCommands.appendChild(row);
-      debugCommands.scrollTop = debugCommands.scrollHeight;
-    };
-
-    const pushLog = (text, tag = 'LOG') => {
-      if (!debugEnabled) return;
-      const row = document.createElement('div');
-      row.className = 'debug-log-line';
-      const badge = document.createElement('span');
-      badge.className = 'tag';
-      badge.textContent = tag;
-      const body = document.createElement('span');
-      body.className = 'text';
-      body.textContent = text;
-      row.appendChild(badge);
-      row.appendChild(body);
-      debugLogs.appendChild(row);
-      debugLogs.scrollTop = debugLogs.scrollHeight;
     };
 
     const stackToggles = Array.from(document.querySelectorAll('[data-stack-toggle]'));
@@ -213,59 +156,6 @@ const statusClasses = {
       rows.forEach(row => refreshRow(row));
     }
 
-    function startUpdateDebugStream(containerId, containerName) {
-      if (!debugStreamSupported) return Promise.reject(new Error('Debug disabilitato'));
-
-      return new Promise((resolve, reject) => {
-        openDebugOverlay(`PULL – ${containerName || containerId}`);
-        pushCommand(`Richiesta aggiornamento per ${containerName || containerId}`);
-
-        const source = new EventSource(`/api/containers/${containerId}/actions/pull/stream`);
-        activeDebugStream = source;
-        let ended = false;
-
-        source.addEventListener('command', (evt) => {
-          const data = safeParseEvent(evt);
-          if (data?.message) pushCommand(data.message);
-        });
-
-        source.addEventListener('status', (evt) => {
-          const data = safeParseEvent(evt);
-          if (data?.state) pushLog(`Stato: ${data.state}`, 'STAT');
-        });
-
-        source.addEventListener('log', (evt) => {
-          const data = safeParseEvent(evt);
-          if (data?.line) pushLog(data.line, 'LOG');
-        });
-
-        source.addEventListener('result', (evt) => {
-          const streamData = safeParseEvent(evt);
-          const row = document.querySelector(`[data-container-id="${containerId}"]`);
-          if (row) {
-             if (streamData && streamData.container_id) {
-                 updateRowContainerId(row, containerId, streamData.container_id);
-             }
-             refreshRow(row);
-          }
-        });
-
-        source.addEventListener('end', () => {
-          ended = true;
-          pushLog('Stream concluso', 'DONE');
-          source.close();
-          activeDebugStream = null;
-          resolve();
-        });
-
-        source.addEventListener('error', () => {
-          pushLog('Stream interrotto', 'ERR');
-          source.close();
-          activeDebugStream = null;
-          if (!ended) reject(new Error('Stream interrotto'));
-        });
-      });
-    }
     function startUpdatesPolling() {
       clearInterval(refreshTimer);
       if (!autoScanEnabled) return;
@@ -294,7 +184,44 @@ const statusClasses = {
     const confirmLoading = document.getElementById('confirm-loading');
     const confirmResult = document.getElementById('confirm-result');
     const confirmActions = document.getElementById('confirm-actions');
+    const confirmPhase = document.getElementById('confirm-phase');
+    const confirmProgress = document.getElementById('confirm-progress');
+    const confirmProgressFill = document.getElementById('confirm-progress-fill');
+    const confirmProgressText = document.getElementById('confirm-progress-text');
+    const confirmLogline = document.getElementById('confirm-logline');
     let pendingForm = null;
+    let updateInProgress = false;
+    let activeUpdateStream = null;
+
+    const updatePhaseLabels = {
+      start: 'Avvio…',
+      inspect: 'Lettura del container…',
+      stopping: 'Arresto e rimozione del container…',
+      cleanup: 'Rimozione vecchia immagine…',
+      pull: 'Scaricamento immagine…',
+      pulled: 'Immagine pronta',
+      recreate: 'Creazione e avvio del nuovo container…',
+      done: 'Completato',
+    };
+
+    function setUpdatePhase(text) {
+      if (confirmPhase && text) confirmPhase.textContent = text;
+    }
+    function setUpdateProgress(percent, label) {
+      if (!confirmProgress) return;
+      confirmProgress.style.display = 'block';
+      if (percent === null || percent === undefined) {
+        confirmProgressFill.classList.add('indeterminate');
+        confirmProgressText.textContent = label || '';
+      } else {
+        confirmProgressFill.classList.remove('indeterminate');
+        confirmProgressFill.style.width = `${Math.max(0, Math.min(100, percent))}%`;
+        confirmProgressText.textContent = label || `${percent}%`;
+      }
+    }
+    function setUpdateLog(text) {
+      if (confirmLogline && text) confirmLogline.textContent = text;
+    }
 
     function resetModalState() {
       messageEl.style.display = 'block';
@@ -311,6 +238,12 @@ const statusClasses = {
       confirmResult.style.display = 'none';
       confirmActions.style.display = 'none';
       confirmTitle.textContent = 'Aggiornamento in corso';
+      // Reset progress UI
+      if (confirmPhase) confirmPhase.textContent = 'Preparazione…';
+      if (confirmProgress) confirmProgress.style.display = 'none';
+      if (confirmProgressFill) { confirmProgressFill.style.width = '0%'; confirmProgressFill.classList.remove('indeterminate'); }
+      if (confirmProgressText) confirmProgressText.textContent = '';
+      if (confirmLogline) confirmLogline.textContent = '';
     }
 
     function showModalResult(success, message) {
@@ -335,8 +268,58 @@ const statusClasses = {
     }
 
     function closeConfirm() {
+      // Don't let the user dismiss the modal while an update is mid-flight.
+      if (updateInProgress) return;
       pendingForm = null;
       modal.classList.remove('visible');
+    }
+
+    function startFullUpdateStream(containerId) {
+      if (typeof EventSource === 'undefined') {
+        return Promise.reject(Object.assign(new Error('EventSource non supportato'), { unsupported: true }));
+      }
+      return new Promise((resolve, reject) => {
+        const source = new EventSource(`/api/containers/${containerId}/full_update/stream`);
+        activeUpdateStream = source;
+        let settled = false;
+        let resultData = null;
+        let sameImage = false;
+
+        const finish = (fn, arg) => {
+          if (settled) return;
+          settled = true;
+          source.close();
+          activeUpdateStream = null;
+          fn(arg);
+        };
+
+        source.addEventListener('progress', (evt) => {
+          const d = safeParseEvent(evt);
+          if (typeof d.same_image === 'boolean') sameImage = d.same_image;
+          if (d.phase && updatePhaseLabels[d.phase]) setUpdatePhase(updatePhaseLabels[d.phase]);
+          if (d.phase === 'pull' && typeof d.percent === 'number') {
+            const lbl = d.total
+              ? `${formatBytes(d.current)} / ${formatBytes(d.total)} · ${d.percent}%`
+              : `${d.percent}%`;
+            setUpdateProgress(d.percent, lbl);
+          } else if (d.phase === 'pulled') {
+            setUpdateProgress(100, '100%');
+          } else {
+            setUpdateProgress(null, '');
+          }
+          if (d.message) setUpdateLog(d.message);
+        });
+
+        source.addEventListener('result', (evt) => { resultData = safeParseEvent(evt); });
+        source.addEventListener('fail', (evt) => {
+          const d = safeParseEvent(evt);
+          finish(reject, new Error(d.message || 'Aggiornamento fallito'));
+        });
+        source.addEventListener('end', () => {
+          finish(resolve, Object.assign({}, resultData, { same_image: sameImage }));
+        });
+        source.onerror = () => { finish(reject, Object.assign(new Error('Connessione interrotta'), { transport: true })); };
+      });
     }
 
     document.querySelectorAll('.full-update-form').forEach(form => {
@@ -371,60 +354,68 @@ const statusClasses = {
       });
     });
 
-    debugClose?.addEventListener('click', closeDebugOverlay);
-    debugClear?.addEventListener('click', clearDebugOverlay);
-    debugOverlay?.addEventListener('click', (evt) => {
-      if (evt.target === debugOverlay) closeDebugOverlay();
-    });
-
     cancelBtn.addEventListener('click', closeConfirm);
     modal.addEventListener('click', (evt) => {
       if (evt.target === modal) closeConfirm();
     });
+
+    function finalizeUpdatedRow(containerId, newContainerId) {
+      const row = document.querySelector(`[data-container-id="${containerId}"]`);
+      if (!row) return;
+      if (newContainerId && newContainerId !== containerId) {
+        updateRowContainerId(row, containerId, newContainerId);
+      }
+      refreshRow(row);
+    }
+
+    async function updateViaPost(containerId, containerName) {
+      try {
+        const res = await fetch(`/api/containers/${containerId}/full_update`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+        const data = await res.json();
+        if (data.success) {
+          finalizeUpdatedRow(containerId, data.container_id);
+          showModalResult(true, `Container "${containerName}" aggiornato con successo!`);
+        } else {
+          showModalResult(false, data.error || 'Errore durante l\'aggiornamento');
+        }
+      } catch (err) {
+        showModalResult(false, 'Errore di connessione al server');
+      }
+    }
 
     confirmBtn.addEventListener('click', async () => {
       if (!pendingForm) return;
 
       const containerId = pendingForm.dataset.containerId;
       const containerName = pendingForm.dataset.containerName || 'container';
+      if (!containerId) { showModalResult(false, 'ID container non valido'); return; }
 
-      // Show loading state
       showModalLoading();
+      updateInProgress = true;
 
-      if (debugStreamSupported && containerId) {
-        try {
-          await startUpdateDebugStream(containerId, containerName);
-          closeConfirm();
+      // Primary path: streamed update with live progress (works without debug mode).
+      try {
+        const result = await startFullUpdateStream(containerId);
+        updateInProgress = false;
+        finalizeUpdatedRow(containerId, result && result.container_id);
+        showModalResult(true, (result && result.same_image)
+          ? `"${containerName}" era già all'ultima versione.`
+          : `Container "${containerName}" aggiornato con successo!`);
+        return;
+      } catch (err) {
+        updateInProgress = false;
+        if (err && err.unsupported) {
+          // Browser without EventSource: fall back to the blocking POST.
+          await updateViaPost(containerId, containerName);
           return;
-        } catch (err) {
-          console.warn('Stream debug non disponibile, procedo con API POST', err);
         }
-      }
-
-      // Fallback: use POST API endpoint
-      if (containerId) {
-        try {
-          const res = await fetch(`/api/containers/${containerId}/full_update`, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
-          const data = await res.json();
-
-          const row = document.querySelector(`[data-container-id="${containerId}"]`);
-
-          if (data.success) {
-            if (row) {
-                 if (data.container_id) updateRowContainerId(row, containerId, data.container_id);
-                 refreshRow(row);
-            }
-            showModalResult(true, `Container "${containerName}" aggiornato con successo!`);
-          } else {
-            console.error('Update failed:', data.error);
-            showModalResult(false, data.error || 'Errore durante l\'aggiornamento');
-          }
-        } catch (err) {
-          console.error('Update request failed:', err);
-          showModalResult(false, 'Errore di connessione al server');
+        if (err && err.transport) {
+          // Connection dropped, but the update runs decoupled on the server.
+          showModalResult(false, 'Connessione persa durante lo streaming. L\'aggiornamento prosegue in background: aggiorna la pagina tra qualche istante.');
+          setTimeout(() => finalizeUpdatedRow(containerId, null), 5000);
+          return;
         }
-      } else {
-        showModalResult(false, 'ID container non valido');
+        showModalResult(false, (err && err.message) || 'Errore durante l\'aggiornamento');
       }
     });
 

--- a/d2ha/templates/updates.html
+++ b/d2ha/templates/updates.html
@@ -181,39 +181,36 @@
     </div>
   </div>
 
-  <div class="debug-overlay" id="debug-overlay" aria-hidden="true">
-    <div class="debug-panel">
-      <div class="debug-header">
-        <div>
-          <div class="debug-eyebrow">Debug live</div>
-          <div class="debug-title" id="debug-title">Stream aggiornamento</div>
-        </div>
-        <div class="debug-actions">
-          <button class="inline-btn" type="button" id="debug-clear">Pulisci</button>
-          <button class="inline-btn" type="button" id="debug-close">Chiudi</button>
-        </div>
-      </div>
-      <div class="debug-body">
-        <div class="debug-column">
-          <div class="debug-subtitle">Comandi</div>
-          <div class="debug-list" id="debug-commands"></div>
-        </div>
-        <div class="debug-column">
-          <div class="debug-subtitle">Log live</div>
-          <div class="debug-log" id="debug-logs"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-
+  <style>
+    .update-progress { margin: 12px 0 4px; }
+    .update-progress-track {
+      width: 100%; height: 8px; border-radius: 999px;
+      background: rgba(127, 127, 127, 0.25); overflow: hidden;
+    }
+    .update-progress-fill {
+      height: 100%; width: 0%; border-radius: 999px;
+      background: var(--accent, #3b82f6);
+      transition: width 0.25s ease;
+    }
+    .update-progress-fill.indeterminate {
+      width: 35% !important; animation: d2ha-indef 1.1s ease-in-out infinite;
+    }
+    @keyframes d2ha-indef { 0% { margin-left: -35%; } 100% { margin-left: 100%; } }
+    .update-progress-pct { margin: 6px 0 0; opacity: 0.8; }
+    #confirm-logline { font-family: ui-monospace, monospace; opacity: 0.75; min-height: 1.2em; }
+  </style>
   <div class="safe-confirm-backdrop" id="confirm-modal">
     <div class="safe-confirm-modal">
       <h3 class="safe-confirm-title" id="confirm-title">Aggiornare l'immagine?</h3>
       <p id="confirm-message" class="safe-confirm-message small"></p>
       <div id="confirm-loading" class="confirm-loading" style="display: none;">
         <div class="spinner"></div>
-        <p class="loading-text">Aggiornamento in corso...</p>
-        <p class="loading-hint small">Pull immagine, rimozione e ricreazione container</p>
+        <p class="loading-text" id="confirm-phase">Aggiornamento in corso...</p>
+        <div class="update-progress" id="confirm-progress" style="display: none;">
+          <div class="update-progress-track"><div class="update-progress-fill" id="confirm-progress-fill"></div></div>
+          <p class="update-progress-pct small" id="confirm-progress-text"></p>
+        </div>
+        <p class="loading-hint small" id="confirm-logline">Pull immagine, rimozione e ricreazione container</p>
       </div>
       <p id="confirm-result" class="confirm-result small" style="display: none;"></p>
       <div class="safe-confirm-actions" id="confirm-actions">


### PR DESCRIPTION
## Cosa cambia
**Progresso live dell'aggiornamento** (era una rotellina statica):
- Nuovo endpoint **SSE** `GET /api/containers/<id>/full_update/stream` (senza richiedere la debug mode) che trasmette le fasi dell'update.
- Il modale ora mostra **fase corrente**, **barra di avanzamento del download** (byte + % aggregati su tutti i layer) e una **riga di log live**.
- L'update gira in un **thread in background** disaccoppiato dalla connessione SSE: se il client si disconnette a metà pull, il container non resta più rimosso-ma-non-ricreato.
- Il modale non è chiudibile durante l'update; mantenuto il fallback `POST /full_update` per i browser senza EventSource.

**Versioni / changelog:**
- Non si usa più `org.opencontainers.image.revision` (un SHA VCS) come "versione".
- Token GitHub opzionale (`D2HA_GITHUB_TOKEN`) per alzare il rate limit della releases API (60 → 5000 req/h), così il rilevamento changelog/breaking continua a funzionare.

**Pulizia / hygiene:**
- Rimosso il vecchio percorso debug-overlay dell'update (funzione, helper, handler e HTML), ora superato dalla UI di progresso integrata.
- Aggiunto `.dockerignore` per tenere segreti e cruft (`auth_config.json`, `data/`, `.env`, `.venv`, `__pycache__`) fuori dall'immagine.

## Perché
Durante un aggiornamento l'utente vedeva solo una rotellina con testo fisso e non capiva se l'app stesse lavorando o fosse bloccata. Ora il download è visibile in tempo reale. In più si correggono comportamenti fuorvianti su versione/changelog e si rende l'update robusto a disconnessioni.

## Come testare
- [x] Ho testato localmente
- [x] Ho aggiornato la documentazione (N/A: nessun cambio d'uso, solo env opzionale `D2HA_GITHUB_TOKEN`)
1. Apri **Aggiornamenti**, su un container con update disponibile clicca **Aggiorna** → conferma.
2. Verifica che il modale mostri fase, **barra con % e byte** e log che avanzano (non più rotellina ferma).
3. (Robustezza) Chiudendo la connessione a metà pull, il container viene comunque ricreato correttamente lato server.

## Checklist
- [x] PR documentata (feature + pulizia)
- [x] Niente credenziali o token nel codice/log
- [x] Lint/Test passano — 11/11 (`pytest`); verifiche statiche su Python, logica progresso, Jinja e JS
