### PR TITLE
fix(mqtt): ancora i topic di discovery allo stable_id per evitare dup…

### DIFF
--- a/d2ha/mqtt/manager.py
+++ b/d2ha/mqtt/manager.py
@@ -14,7 +14,7 @@ except ImportError:
 
 from services.docker import DockerService
 from services.preferences import AutodiscoveryPreferences
-from services.utils import build_stable_id, slugify_container
+from services.utils import build_stable_id
 
 class MqttManager:
     def __init__(
@@ -407,8 +407,13 @@ class MqttManager:
     def _publish_discovery_for_container(
         self, c: Dict[str, Any], device_info: Dict[str, Any], preferences: Dict[str, Any]
     ):
-        slug = slugify_container(c["name"], c["short_id"])
         stable_id = build_stable_id(c)
+        # Topic/entity identity is keyed on the STABLE id (stack+name), NOT on the
+        # Docker short_id. Embedding the short_id meant every container recreation or
+        # d2ha restart published the discovery config to a *new* topic while the old
+        # retained config lingered in the broker, both carrying the same stable
+        # unique_id -> Home Assistant logs "unique ID already exists - ignoring".
+        slug = stable_id
         self.container_slug_map[slug] = c["id"]
 
         state_topic = f"{self.base_topic}/{slug}/state"
@@ -498,7 +503,7 @@ class MqttManager:
             if self._is_self_container(c):
                 continue
 
-            slug = slugify_container(c["name"], c["short_id"])
+            slug = build_stable_id(c)
             current_slugs.add(slug)
 
             try:


### PR DESCRIPTION
…licati in HA

Il topic di discovery MQTT era costruito sullo slug basato sullo short_id Docker (volatile), mentre lo unique_id usa lo stable_id (stack+nome). A ogni ricreazione di un container o riavvio di d2ha il vecchio config retained restava orfano nel broker e collideva sullo stesso unique_id, generando in Home Assistant migliaia di "unique ID already exists - ignoring". Il cleanup degli slug stale non li intercettava perche' la mappa e' in memoria e riparte vuota a ogni restart.

Ora i topic di stato/comando/discovery sono ancorati allo stable_id: le ricreazioni e i riavvii sovrascrivono lo stesso topic invece di lasciare orfani. Lo unique_id resta invariato, quindi le entita' HA mantengono identita' e storico.

## Cosa cambia
<!-- Spiega cosa fa la PR in 2-4 righe. -->

## Perché
<!-- Motivazione: bug / feature / refactor. Linka issue/discussion se esiste. -->

## Come testare
<!-- Passi rapidi per test manuale o comando di test -->
- [ ] Ho testato localmente
- [ ] Ho aggiornato la documentazione (se necessario)

## Checklist
- [ ] PR piccola e focalizzata (o spiegata se grande)
- [ ] Niente credenziali o token nel codice/log
- [ ] Lint/Test passano

## Screenshot / Video (se UI)
<!-- Allegali qui -->
